### PR TITLE
Add AWS IAM Authenticator Installation step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,10 @@ RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -  && 
     apt-get update -y && \
     apt-get install -y docker-ce
 
+# Install AWS IAM Authenticator, so AWS services like EKS can be used.
+RUN curl -Lso /usr/bin/aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator && \
+    chmod +x /usr/bin/aws-iam-authenticator
+
 # Install all the cloud CLIs, so we are prepared to deploy to them.
 #     - AWS
 RUN pip install awscli --upgrade


### PR DESCRIPTION
This PRs add a build step that installs AWS IAM Authenticator directly [from the source](https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator). Before creating the this PR, i made a very simple test using one of our projects:

<img width="830" alt="screen shot 2018-11-30 at 22 48 17" src="https://user-images.githubusercontent.com/6279712/49321936-12d4d080-f4f2-11e8-9256-f268886b902d.png">

Everything works great. 🙃