### PR TITLE
Add option for commenting on Pull Requests

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -102,7 +102,7 @@ $OUTPUT
 \`\`\`"
         PAYLOAD=$(echo '{}' | jq --arg body "$COMMENT" '.body = $body')
         echo "Commenting on PR $COMMENTS_URL"
-        curl -s -S -H "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/json" --data "$PAYLOAD" "$COMMENTS_URL"
+        curl -s -S -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/json" --data "$PAYLOAD" "$COMMENTS_URL"
     fi
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -83,4 +83,27 @@ if [ -e package.json ] && [ ! -d node_modules ]; then
 fi
 
 # Now just pass along all arguments to the Pulumi CLI.
-pulumi "$@"
+OUTPUT=$(sh -c "pulumi --non-interactive $*" 2>&1)
+EXIT_CODE=$?
+
+echo "#### :tropical_drink: \`pulumi ${@:2}\`"
+echo "$OUTPUT"
+
+# If the GitHub action stems from a Pull Request event, we may optionally leave a comment if the
+# COMMENT_ON_PR is set.
+COMMENTS_URL=$(cat $GITHUB_EVENT_PATH | jq -r .pull_request.comments_url)
+if [ ! -z $COMMENTS_URL ] && [ ! -z $COMMENT_ON_PR ]; then
+    if [ -z $GITHUB_TOKEN ]; then
+        echo "ERROR: COMMENT_ON_PR was set, but GITHUB_TOKEN is not set."
+    else
+        COMMENT="#### :tropical_drink: \`pulumi ${@:2}\`
+\`\`\`
+$OUTPUT
+\`\`\`"
+        PAYLOAD=$(echo '{}' | jq --arg body "$COMMENT" '.body = $body')
+        echo "Commenting on PR $COMMENTS_URL"
+        curl -s -S -H "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/json" --data "$PAYLOAD" "$COMMENTS_URL"
+    fi
+fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
Add the ability for the `pulumi/actions` container to add the Pulumi command-line output  as comments on pull requests. (As suggested by @najohnson.)

![image](https://user-images.githubusercontent.com/4029847/51571330-c1442480-1e56-11e9-85fa-dfeeea23d7ce.png)

I've set it up so that we _don't_ leave comment on PRs by default. To get this behavior you need to set to set the `COMMENT_ON_PR` environment variable, as well as make sure `GITHUB_TOKEN` is available to the GitHub workflow action.

Here's a sample `main.workflow`, using the `dev` tag of the container.

```
action "Pulumi Preview chrsmith/github-actions-resources" {
  uses = "docker://pulumi/actions:dev-chris"
  args = ["preview"]
  env = {
    PULUMI_CI = "pr"
    COMMENT_ON_PR = "1"
  }
  secrets = [
    "PULUMI_ACCESS_TOKEN",
    "GITHUB_TOKEN",
  ]
}
```

The reason we don't want to enable this by default, is that if you are using the [Pulumi GitHub app](http://github.com/apps/pulumi) then you'll wind up with 2x messages for every update. Also, the Pulumi GitHub app has more flexibility when it comes to formatting its output. For example, only showing the resources that were changed, or not leaving any comment in the event of a no-op update.

Here is what you'll see if you have the Pulumi GitHub app installed in addition to configuring the GitHub actions workflow to leave a comment.

![image](https://user-images.githubusercontent.com/4029847/51571518-2ef05080-1e57-11e9-9699-edb51e7ed552.png)

Assuming this is the way we want to go about this. Instead of, say, adding a configuration option in `.pulumi/ci.json`, I'll be sure to call it out on the relevant documentation on https://pulumi.io/github.

Fixes #4 