### PR TITLE
Allow Pulumi config vars to be dynamically set

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -77,6 +77,13 @@ if [ ! -z "$GOOGLE_CREDENTIALS" ]; then
     gcloud auth activate-service-account --key-file=$GCLOUD_KEYFILE
 fi
 
+# Add pulumi config vars
+for varname in ${!PULUMI_CONFIG*}
+do
+    echo setting ${varname/PULUMI_CONFIG_/}=${!varname}
+    pulumi config set ${varname/PULUMI_CONFIG_/} ${!varname}
+done
+
 # Next, lazily install packages if required.
 if [ -e package.json ] && [ ! -d node_modules ]; then
     npm install


### PR DESCRIPTION
- This PR allows pulumi vars to be automatically set from environment variables passed by Github Action
- Setting a secret in GH such as "PULUMI_CONFIG_XYZ=20" would set pulumi config XYZ to be 20