### PR TITLE
feat: Add configuration

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -9,7 +9,7 @@ inputs:
         description: 'Pulumi command to run, eg. up'
         required: true
     stack-name:
-        description: 'Pulumi Access Token'
+        description: 'Which stack you want to apply to, eg. dev'
         required: true
 runs:
     using: 'node12'

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "scripts": {
     "clean": "rimraf coverage build tmp dist",
     "build": "ncc build src/main.ts -o dist --source-map --license LICENSE",
-    "build:watch": "tsc -w -p tsconfig.release.json",
     "lint": "eslint . --ext .ts,.tsx",
     "test": "jest --coverage src/**/*",
     "test:watch": "jest --watch"
@@ -28,5 +27,9 @@
     "rimraf": "~3.0.2",
     "ts-jest": "~26.4.4",
     "typescript": "~4.1.3"
+  },
+  "dependencies": {
+    "@actions/core": "^1.2.6",
+    "runtypes": "^5.0.1"
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,22 @@
+import { getInput } from '@actions/core';
+import * as rt from 'runtypes';
+
+export const command = rt.Union(
+  rt.Literal('up'),
+  rt.Literal('refresh'),
+  rt.Literal('destroy'),
+);
+
+export const config = rt.Record({
+  command: command,
+  stackName: rt.String,
+});
+
+export type Config = rt.Static<typeof config>;
+
+export async function makeConfig(): Promise<Config> {
+  return config.check({
+    command: getInput('command', { required: true }),
+    stackName: getInput('stack-name', { required: true }),
+  });
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,7 @@ export const command = rt.Union(
   rt.Literal('up'),
   rt.Literal('refresh'),
   rt.Literal('destroy'),
+  rt.Literal('preview'),
 );
 
 export const config = rt.Record({

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,6 @@
+import { makeConfig } from "./config";
+
 (async () => {
+  const config = await makeConfig();
   // ...
 })();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@actions/core@^1.2.6":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.2.6.tgz#a78d49f41a4def18e88ce47c2cac615d5694bf09"
+  integrity sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA==
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
@@ -3470,6 +3475,11 @@ run-parallel@^1.1.9:
   version "1.1.10"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.10.tgz#60a51b2ae836636c81377df16cb107351bcd13ef"
   integrity sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==
+
+runtypes@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/runtypes/-/runtypes-5.0.1.tgz#406d140410266f6ece17c3501a37234f91faa346"
+  integrity sha512-+TWVlCmFsgrG4Nd2u+ambpNFO8Yp4heAflGQi9oNj6GRkxZo8aSDBxO1Y0vlKIQCWKKFxato+8Hn67XeAqKhRA==
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.2:
   version "5.2.1"


### PR DESCRIPTION
This adds configuration to our action step.

There's one small catch, we are evaluating the input variables multiple times. In `action.yml` and on every input which is required we validate as well, the problem is that we don't get types based on either of these validations and generally I don't like typecasting.

`runtypes` offers more than what the Github Actions configuration does as well.

fixes #45