### PR TITLE
feat: Check if Pulumi CLI is available

### DIFF
--- a/src/libs/exec.ts
+++ b/src/libs/exec.ts
@@ -1,0 +1,38 @@
+import * as aexec from '@actions/exec';
+import { ExecOptions } from '@actions/exec';
+
+export interface ExecResult {
+  success: boolean;
+  stdout: string;
+  stderr: string;
+}
+
+export const exec = async (
+  command: string,
+  args: string[] = [],
+  silent?: boolean,
+): Promise<ExecResult> => {
+  let stdout: string = '';
+  let stderr: string = '';
+
+  const options: ExecOptions = {
+    silent: silent,
+    ignoreReturnCode: true,
+  };
+  options.listeners = {
+    stdout: (data: Buffer) => {
+      stdout += data.toString();
+    },
+    stderr: (data: Buffer) => {
+      stderr += data.toString();
+    },
+  };
+
+  const returnCode: number = await aexec.exec(command, args, options);
+
+  return {
+    success: returnCode === 0,
+    stdout: stdout.trim(),
+    stderr: stderr.trim(),
+  };
+};

--- a/src/libs/pulumi-cli.ts
+++ b/src/libs/pulumi-cli.ts
@@ -1,0 +1,6 @@
+import * as exec from './exec';
+
+export async function isAvailable(): Promise<Boolean> {
+  const res = await exec.exec(`pulumi`, [], true)
+  return (res.stderr != '' && !res.success) ? false : res.success;
+}

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -2,7 +2,7 @@ export function invariant(
   condition: any,
   message?: string,
 ): asserts condition {
-  if (condition) {
+  if (!condition) {
     throw new Error(message);
   }
 }

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -1,0 +1,8 @@
+export function invariant(
+  condition: any,
+  message?: string,
+): asserts condition {
+  if (condition) {
+    throw new Error(message);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,11 @@
-import { makeConfig } from "./config";
+import { makeConfig } from './config';
+import * as pulumiCli from './libs/pulumi-cli';
+import { invariant } from './libs/utils';
 
 (async () => {
   const config = await makeConfig();
-  // ...
+
+  invariant(pulumiCli.isAvailable(), 'Pulumi CLI is not available.');
+
+  console.log(config);
 })();


### PR DESCRIPTION
Adds a check to see if Pulumi CLI is available.

**Note**: The implementation is heavily inspired by [docker/build-push-action](https://github.com/docker/build-push-action).