### PR TITLE
feat: Add cwd to inputs

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -5,12 +5,15 @@ branding:
   icon: upload-cloud
   color: purple
 inputs:
-    command:
-        description: 'Pulumi command to run, eg. up'
-        required: true
-    stack-name:
-        description: 'Which stack you want to apply to, eg. dev'
-        required: true
+  command:
+    description: 'Pulumi command to run, eg. up'
+    required: true
+  stack-name:
+    description: 'Which stack you want to apply to, eg. dev'
+    required: true
+  cwd:
+    description: 'Location of your Pulumi files. Defaults to ./'
+    required: false
 runs:
-    using: 'node12'
-    main: 'dist/index.js'
+  using: 'node12'
+  main: 'dist/index.js'

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,7 @@ export const command = rt.Union(
 export const config = rt.Record({
   command: command,
   stackName: rt.String,
+  cwd: rt.String,
 });
 
 export type Config = rt.Static<typeof config>;
@@ -19,5 +20,6 @@ export async function makeConfig(): Promise<Config> {
   return config.check({
     command: getInput('command', { required: true }),
     stackName: getInput('stack-name', { required: true }),
+    cwd: getInput('cwd') || './',
   });
 }


### PR DESCRIPTION
This configuration is used to define where the Pulumi code is located. We probably need this argument to ensure we are updating the correct Pulumi code, and AFAIK there is no other way to define this.

Maybe we want `working-directory` as is defined in [Workflow Syntax](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions) for the run command?

I went for `cwd` since that is _not_ `working-directory`, so that people don't miss where to put the input variable :)