### PR TITLE
fix: add missing `cloud-url`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
   github-token:
     description: 'Github Token (required to comment on pull requests)'
     required: false
+  cloud-url:
+    description: 'A cloud URL to log in to'
+    required: false
 runs:
   using: 'node12'
   main: 'dist/index.js'


### PR DESCRIPTION
Fixes issue causing this error:

```shell
Warning: Unexpected input(s) 'cloud-url', valid inputs are ['command', 'stack-name', 'work-dir', 'comment-on-pr', 'github-token']
```