### PR TITLE
feat: Add auto major-tagger workflow

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -10,4 +10,4 @@ jobs:
         env:
           GITHUB_TOKEN: '${{ github.token }}'
         with:
-          publish_latest_tag: true
+          publish_latest_tag: false

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -1,0 +1,13 @@
+on:
+  release:
+    types: [published, edited]
+jobs:
+  tag-major:
+    name: Push major-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Actions-R-Us/actions-tagger@latest
+        env:
+          GITHUB_TOKEN: '${{ github.token }}'
+        with:
+          publish_latest_tag: true


### PR DESCRIPTION
This pull request adds a Github Workflow that runs on every release and pushes to a `v<major tag>` tag.

E.g.
`1.0.0` --> `v1`
`v1.0.0` --> `v1`
`v2.1.4` --> `v2`
....

**PS**: I have explicitly removed the `latest` tag to discourage users from blindly using `latest` and getting problems :-)

See live demo:
https://github.com/cobraz/workflow-testing/runs/1954713139