### PR TITLE
ci: enable `fail-fast` on `matrix`

### DIFF
--- a/.github/workflows/workflow_dotnet_application.yml
+++ b/.github/workflows/workflow_dotnet_application.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         command: [ up, refresh, destroy, preview ]
         os: [ubuntu-latest, macos-latest, windows-latest]
-      fail-fast: false
+      fail-fast: true
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1

--- a/.github/workflows/workflow_go_application.yml
+++ b/.github/workflows/workflow_go_application.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         command: [ up, refresh, destroy, preview ]
         os: [ubuntu-latest, macos-latest, windows-latest]
-      fail-fast: false
+      fail-fast: true
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/.github/workflows/workflow_nodejs_application.yml
+++ b/.github/workflows/workflow_nodejs_application.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         command: [ up, refresh, destroy, preview ]
         os: [ubuntu-latest, macos-latest, windows-latest]
-      fail-fast: false
+      fail-fast: true
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/.github/workflows/workflow_options.yml
+++ b/.github/workflows/workflow_options.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         command: [ up, refresh, destroy, preview ]
         os: [ubuntu-latest, macos-latest, windows-latest]
-      fail-fast: false
+      fail-fast: true
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/.github/workflows/workflow_python_application.yml
+++ b/.github/workflows/workflow_python_application.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         command: [ up, refresh, destroy, preview ]
         os: [ubuntu-latest, macos-latest, windows-latest]
-      fail-fast: false
+      fail-fast: true
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2


### PR DESCRIPTION
We're hitting the maximum running jobs (60) on GHA all the time, which is fine. The issue is that if we notice something wrong with one workflow (e.g. `up`), we shouldn't need to wait until everyone is completed.