### PR TITLE
Add date to the version record

### DIFF
--- a/src/libs/libs/get-version.ts
+++ b/src/libs/libs/get-version.ts
@@ -5,6 +5,7 @@ import { invariant } from '../utils';
 
 const VersionRt = rt.Record({
   version: rt.String,
+  date: rt.String,
   downloads: rt.Record({
     'linux-x64': rt.String,
     'linux-arm64': rt.String,


### PR DESCRIPTION
Adds a `date` property for the ISO date string returned by the GitHub API that corresponds with a given release. See https://github.com/pulumi/docs/pull/6036 for additional context.