### PR TITLE
Print collapsible comments on PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ---
 
+## 3.16.0 (2022-02-09)
+
+- Print the comments as a collapsed `<details>` section
+
 ## 3.15.0 (2022-01-04)
 
 - Upgrade to Pulumi v3.21.0

--- a/src/libs/pr.ts
+++ b/src/libs/pr.ts
@@ -15,7 +15,11 @@ export async function handlePullRequestMessage(
     options: { editCommentOnPr },
   } = config;
 
-  const heading = `#### :tropical_drink: \`${command}\` on ${stackName}`;
+  const heading = `#### :tropical_drink: \`${command}\` on ${stackName}
+
+  <details>
+  <summary>Click to expand Pulumi report</summary>`;
+
   const rawBody = output.substring(0, 64_000);
   const body = dedent`
     ${heading}
@@ -27,6 +31,7 @@ export async function handlePullRequestMessage(
         ? '**Warn**: The output was too long and trimmed.'
         : ''
     }
+    </details>
   `;
 
   const { payload, repo } = context;


### PR DESCRIPTION
Instead of printing the whole comment "raw", print it collapsed so it doesn't take a lot of space on screen!