### PR TITLE
Fix collapsible comment

### DIFF
--- a/src/libs/pr.ts
+++ b/src/libs/pr.ts
@@ -21,8 +21,11 @@ export async function handlePullRequestMessage(
   <summary>Click to expand Pulumi report</summary>`;
 
   const rawBody = output.substring(0, 64_000);
+  // a line break between heading and rawBody is needed
+  // otherwise the backticks won't work as intended
   const body = dedent`
     ${heading}
+
     \`\`\`
     ${rawBody}
     \`\`\`


### PR DESCRIPTION
There has to be a line break after the `summary` block so that the
backticks work as intended.

We have found this issue while trying to latest version from master.
Check the screen shot below.

<img width="690" alt="image" src="https://user-images.githubusercontent.com/2359543/160108017-9bb34309-01bc-4753-9c3a-36c8d123b5b1.png">

Edit: 

I noticed that the pipeline failed because it's requesting for the changelog to be updated. Does it need to be as there was no release of this feature yet?
