### PR TITLE
fix: update PR comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,15 @@
 
 ## HEAD (Unreleased)
 
-_(none)_
+- fix: update PR comments correctly when `edit-pr-comment` is true (fixes
+  [#633](https://github.com/pulumi/actions/issues/633))
 
 ---
 
 ## 3.17.0 (2022-05-25)
 
-- Fixes errors when pull request comment body is too large by trimming the body when above 64k characters
+- Fixes errors when pull request comment body is too large by trimming the body
+  when above 64k characters
 
 ## 3.16.0 (2022-02-09)
 

--- a/src/libs/pr.ts
+++ b/src/libs/pr.ts
@@ -15,16 +15,17 @@ export async function handlePullRequestMessage(
     options: { editCommentOnPr },
   } = config;
 
-  const heading = `#### :tropical_drink: \`${command}\` on ${stackName}
-
-  <details>
-  <summary>Click to expand Pulumi report</summary>`;
+  const heading = `#### :tropical_drink: \`${command}\` on ${stackName}`;
+  const summary = '<summary>Click to expand Pulumi report</summary>';
 
   const rawBody = output.substring(0, 64_000);
   // a line break between heading and rawBody is needed
   // otherwise the backticks won't work as intended
   const body = dedent`
     ${heading}
+
+    <details>
+    ${summary}
 
     \`\`\`
     ${rawBody}
@@ -49,7 +50,7 @@ export async function handlePullRequestMessage(
         issue_number: payload.pull_request.number,
       });
       const comment = comments.find((comment) =>
-        comment.body.startsWith(heading),
+        comment.body.startsWith(heading) && comment.body.includes(summary),
       );
 
       // If comment exists, update it.


### PR DESCRIPTION
This is a fix for #633.

The problem appears to be from the usage of dedent, which produces mixed indentation levels between `heading` and `body`. On current master, one ends up with a `heading` that looks like this:

```
#### :tropical_drink: `up` on pr-comment

<details>
<summary>Click to expand Pulumi report</summary>
```

and a `body` that looks like this (note the extra indentation):
```
#### :tropical_drink: `up` on pr-comment
   <details>
   <summary>Click to expand Pulumi report</summary>
```

I considered amending the indentation of the `body` string (basically, removing it all), but that would require some unusual formatting that would break the flow of the code, and seems brittle. This change should be a little more robust.

Ideally there would be unit test coverage for this case, but I didn't have time to add it.