### PR TITLE
chore: add workflows to change trigger

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -33,6 +33,7 @@ jobs:
           filters: |
             dist:
               - 'dist/**'
+              - .github/workflows/**
 
       - name: Upload artifacts
         if: steps.changes.outputs.dist == 'true'


### PR DESCRIPTION
Workflow builds aren't triggered due to our change detector step only checking `dist` folder. We should also run builds when workflows are updated, this addresses that.