### PR TITLE
feat: Support colorized output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ---
 
+## 3.17.1 (2022-06-22)
+- Add support for colorized output
+  [#662](https://github.com/pulumi/actions/pull/662)
+
 ## 3.17.0 (2022-05-25)
 
 - Fixes errors when pull request comment body is too large by trimming the body

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ The action can be configured with the following arguments:
   `awskms`, `azurekeyvault`, `gcpkms`, `hashivault`. e.g.
   `gcpkms://projects//locations/us-west1/keyRings/acmecorpsec/cryptoKeys/payroll `
 
+- `color` - (optional) Colorize output. Choices are: always, never, raw, auto (default "auto").
+
 ### Extra options
 
 - `parallel` - (optional) Allow P resource operations to run in parallel at once

--- a/action.yml
+++ b/action.yml
@@ -67,6 +67,10 @@ inputs:
     description: 'Edit previous PR comment instead of posting new one'
     required: false
     default: 'true'
+  color:
+    description: 'Colorize output. Choices are: always, never, raw, auto'
+    required: false
+    default: 'auto'
 outputs:
   output:
     description: Output from running command

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -33,6 +33,7 @@ describe('config.ts', () => {
         "commentOnPr": false,
         "githubToken": "n/a",
         "options": Object {
+          "color": undefined,
           "diff": undefined,
           "editCommentOnPr": undefined,
           "expectNoChanges": undefined,
@@ -87,6 +88,7 @@ describe('config.ts', () => {
         "commentOnPr": true,
         "githubToken": "n/a",
         "options": Object {
+          "color": undefined,
           "diff": undefined,
           "editCommentOnPr": undefined,
           "expectNoChanges": undefined,

--- a/src/config.ts
+++ b/src/config.ts
@@ -67,6 +67,7 @@ export async function makeConfig(): Promise<Config> {
       targetDependents: parseBoolean(getInput('target-dependents')),
       editCommentOnPr: parseBoolean(getInput('edit-pr-comment')),
       userAgent: 'pulumi/actions@v3',
+      color: getInput('color'),
     },
   });
 }


### PR DESCRIPTION
Adds support for configuring colorized output.

I am unsure what exactly is required for contributing to this repo. Please let me know if something more is needed.

Fixes #84 