### PR TITLE
fix click language

### DIFF
--- a/src/libs/pr.ts
+++ b/src/libs/pr.ts
@@ -16,7 +16,7 @@ export async function handlePullRequestMessage(
   } = config;
 
   const heading = `#### :tropical_drink: \`${command}\` on ${stackName}`;
-  const summary = '<summary>Click to expand Pulumi report</summary>';
+  const summary = '<summary>Pulumi report</summary>';
 
   const rawBody = output.substring(0, 64_000);
   // a line break between heading and rawBody is needed


### PR DESCRIPTION
i noticed this in demos today, so fixing up.

have been working to remove the click language, as its pointer centric. the expand language does not apply after its been expanded so is unnecessary, and the accordion gives the affordance that you can toggle the view.

this updates the language to communicate the content that is contained in the accordion.