### PR TITLE
Prevent Command Substitution in bash step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,4 +55,4 @@ jobs:
           upsert: true
           work-dir: .github/test-stacks/golang
           configMap: "{name: {value: test, secret: false}}"
-      - run: echo "The random string is `${{ steps.pulumi.outputs.name }}`"
+      - run: echo 'The random string is `${{ steps.pulumi.outputs.name }}`'


### PR DESCRIPTION
If the random string generated contains valid bash syntax for command substitutions, this script as-is could throw an error if the substitution itself is invalid. See https://github.com/pulumi/actions/runs/7292938581?check_suite_focus=true for an example. Instead, the Bash string should use single quotes to prevent globbing, splitting, and substitutions.