### PR TITLE
Clarify one-feature-per-pr in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,10 @@
 
 We :heart: PRs! If you have something you'd like to contribute, please open an issue first. We're happy to talk with you about your pull request before you get started.
 
+For larger features, we'd appreciate it if you open a [new issue](https://github.com/pulumi/actions/issues/new) before investing a lot of time so we can discuss the feature together.
+Please also be sure to browse [current issues](https://github.com/pulumi/actions/issues) to make sure your issue is unique, to lighten the triage burden on our maintainers.
+Finally, please limit your pull requests to contain only one feature at a time. Separating feature work into individual pull requests helps speed up code review and reduces the barrier to merge.
+
 ## Release Process
 
 This section details the steps necessary to cut a new release. Suppose the latest release is `v3.18.1`, and you wish to cut `v.3.19.0`.


### PR DESCRIPTION
This PR clarifies that we prefer each PR to contain no more than one new feature. It also adds copy from pu/pu CONTRIBUTING.md to link community members to issues.