### PR TITLE
Document sunsetting policy for Node 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,3 +224,12 @@ As of `v3.18`, we are intending to move to a monthly cadence for minor releases.
 Minor releases will be published around the beginning of the month. We may cut a
 patch release instead, if the changes are small enough not to warrant a minor
 release. We will also cut patch releases periodically as needed to address bugs.
+
+## Node 12 Support Ending 2022-12-07
+
+We intend this action to work for all GitHub users, both SaaS users and GitHub
+Enterprise users. As such, this action will continue to use Node 12 until all
+maintained versions of GitHub Enterprise have Node 16 support. This date is
+2022-12-07, when GitHub Enterprise v3.3 is sunset. After 2022-12-07, this action
+will upgrade to Node 16, and will no longer run on GitHub Actions runners
+without Node 16 support.


### PR DESCRIPTION
This PR documents our intention to support our enterprise customers. As part of a "Pulumi EOL" issue, I did some reading to determine what kind of policies we can publish around version support -- in the case of this repo, only Node support is required to disclose, since yarn, typescript, etc are all build-time dependencies.

It also provides a public announcement of our intention to end support for Node 12 in December.

Closes https://github.com/pulumi/actions/issues/707