### PR TITLE
allow PR comment from non-PR events using `comment-on-pr-number`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## HEAD (Unreleased)
 
-_(none)_
+- fix: allow `comment-on-pr-number` to be used for `${{ github.event }}` types
+  other than `pull_request`
+  ([#803](https://github.com/pulumi/actions/issues/803))
 
 --
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ The action can be configured with the following arguments:
   with the correct access credentials for that backend.
 
 - `comment-on-pr` - (optional) If `true`, then the action will add the results
-  of the Pulumi action to the PR
+  of the Pulumi action to the PR. Ignored unless `${{ github.event }}` type is
+  `pull_request`.
 
 - `github-token` - (optional) A GitHub token that has access levels to allow the
   Action to comment on a PR. Defaults to `${{ github.token }}`
@@ -60,7 +61,7 @@ The action can be configured with the following arguments:
 - `secrets-provider` - (optional) The type of the provider that should be used
   to encrypt and decrypt secrets. Possible choices: `default`, `passphrase`,
   `awskms`, `azurekeyvault`, `gcpkms`, `hashivault`. e.g.
-  `gcpkms://projects//locations/us-west1/keyRings/acmecorpsec/cryptoKeys/payroll `
+  `gcpkms://projects//locations/us-west1/keyRings/acmecorpsec/cryptoKeys/payroll`
 
 - `color` - (optional) Colorize output. Choices are: always, never, raw, auto
   (default "auto").
@@ -72,6 +73,9 @@ The action can be configured with the following arguments:
 
 - `diff` - (optional) Display operation as a rich diff showing the overall
   change.
+
+- `comment-on-pr-number` - (optional) If set to a number, then the action will
+  add the results of the Pulumi action to the specified PR number.
 
 - `edit-pr-comment` - (optional) Edit previous PR comment instead of posting new
   one. **PLEASE NOTE:** that as of 3.2.0 of the Action, this now defaults to

--- a/src/main.ts
+++ b/src/main.ts
@@ -93,14 +93,17 @@ const main = async () => {
     }
   }
 
-  if (config.commentOnPr && config.isPullRequest) {
+  if (
+    config.commentOnPrNumber ||
+    (config.commentOnPr && config.isPullRequest)
+  ) {
     core.debug(`Commenting on pull request`);
     invariant(config.githubToken, 'github-token is missing.');
     handlePullRequestMessage(config, projectName, output);
   }
 
   if (config.remove && config.command === 'destroy') {
-    stack.workspace.removeStack(stack.name)
+    stack.workspace.removeStack(stack.name);
   }
 
   core.endGroup();


### PR DESCRIPTION
Allow `comment-on-pr-number` to be used to comment on a PR, even when not called from a `pull_request` event.

Fixes #802 