### PR TITLE
feat: added multi-comment-support on the same PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## HEAD (Unreleased)
 
+- feat: Add multi-comment support on the same PR using comment identifiers
+  [#809](https://github.com/pulumi/actions/pull/809)
+
 --
 
 ## 4.3.0 (2023-05-12)

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,9 @@ inputs:
     description: 'If true, a comment will be created with results'
     required: false
     default: 'false'
+  comment-on-pr-id:
+    description: 'Hidden id to support multiple comments in one PR'
+    required: false
   comment-on-pr-number:
     description: 'Overrides the PR used to comment on'
     required: false

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -38,6 +38,7 @@ describe('config.ts', () => {
         "cloudUrl": "file://~",
         "command": "up",
         "commentOnPr": false,
+        "commentOnPrId": "",
         "commentOnPrNumber": undefined,
         "configMap": undefined,
         "editCommentOnPr": false,

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,6 +42,7 @@ export function makeConfig() {
     cloudUrl: getInput('cloud-url'),
     githubToken: getInput('github-token'),
     commentOnPr: getBooleanInput('comment-on-pr'),
+    commentOnPrId: getInput('comment-on-pr-id'),
     commentOnPrNumber: getNumberInput('comment-on-pr-number', {}),
     upsert: getBooleanInput('upsert'),
     remove: getBooleanInput('remove'),

--- a/src/libs/__tests__/pr.test.ts
+++ b/src/libs/__tests__/pr.test.ts
@@ -5,7 +5,7 @@ import { handlePullRequestMessage } from '../pr';
 const comments = [
   {
     id: 2,
-    body: '#### :tropical_drink: `preview` on myFirstProject/staging. <summary>Pulumi report</summary>',
+    body: '#### :tropical_drink: `preview` on myFirstProject/staging. <summary>Pulumi report</summary><!-- pulumi-comment-id: some-comment-staging-id -->',
   },
 ];
 const resp = { data: comments };
@@ -50,7 +50,7 @@ describe('pr.ts', () => {
 
     await handlePullRequestMessage(defaultOptions, projectName, 'test');
     expect(createComment).toHaveBeenCalledWith({
-      body: '#### :tropical_drink: `preview` on myFirstProject/staging\n\n<details>\n<summary>Pulumi report</summary>\n\n```\ntest\n```\n\n</details>',
+      body: '#### :tropical_drink: `preview` on myFirstProject/staging\n\n<details>\n<summary>Pulumi report</summary>\n\n```\ntest\n```\n\n</details>\n<!-- pulumi-comment-id: default -->',
       issue_number: 123,
     });
   });
@@ -142,7 +142,31 @@ describe('pr.ts', () => {
     await handlePullRequestMessage(options, projectName, 'test');
     expect(updateComment).toHaveBeenCalledWith({
       comment_id: 2,
-      body: '#### :tropical_drink: `preview` on myFirstProject/staging\n\n<details>\n<summary>Pulumi report</summary>\n\n```\ntest\n```\n\n</details>',
+      body: '#### :tropical_drink: `preview` on myFirstProject/staging\n\n<details>\n<summary>Pulumi report</summary>\n\n```\ntest\n```\n\n</details>\n<!-- pulumi-comment-id: default -->',
+    });
+  });
+
+  it('should edit the comment if it finds a previous created one by the comment id', async () => {
+    // @ts-ignore
+    gh.context = {
+      payload: {
+        pull_request: {
+          number: 123,
+        },
+      },
+    };
+
+    const options = {
+      command: 'preview',
+      stackName: 'staging',
+      commentOnPrId: 'some-comment-staging-id',
+      editCommentOnPr: true,
+    } as Config;
+
+    await handlePullRequestMessage(options, projectName, 'test');
+    expect(updateComment).toHaveBeenCalledWith({
+      comment_id: 2,
+      body: '#### :tropical_drink: `preview` on myFirstProject/staging\n\n<details>\n<summary>Pulumi report</summary>\n\n```\ntest\n```\n\n</details>\n<!-- pulumi-comment-id: some-comment-staging-id -->',
     });
   });
 });

--- a/src/libs/pr.ts
+++ b/src/libs/pr.ts
@@ -19,7 +19,9 @@ export async function handlePullRequestMessage(
   const heading = `#### :tropical_drink: \`${command}\` on ${projectName}/${stackName}`;
 
   const summary = '<summary>Pulumi report</summary>';
-
+  const commentOnPrIdTag = `<!-- pulumi-comment-id: ${
+    config.commentOnPrId ?? 'default'
+  } -->`;
   const rawBody = output.substring(0, 64_000);
   // a line break between heading and rawBody is needed
   // otherwise the backticks won't work as intended
@@ -38,6 +40,7 @@ export async function handlePullRequestMessage(
         : ''
     }
     </details>
+    ${commentOnPrIdTag}
   `;
 
   const { payload, repo } = context;
@@ -53,9 +56,15 @@ export async function handlePullRequestMessage(
         ...repo,
         issue_number: nr,
       });
-      const comment = comments.find((comment) =>
-        comment.body.startsWith(heading) && comment.body.includes(summary),
-      );
+      const comment = comments.find((comment) => {
+        if (config.commentOnPrId) {
+          return comment.body.includes(commentOnPrIdTag);
+        } else {
+          return (
+            comment.body.startsWith(heading) && comment.body.includes(summary)
+          );
+        }
+      });
 
       // If comment exists, update it.
       if (comment) {


### PR DESCRIPTION
This adds a new configuration value to define a hidden comment identifier for pull-request comments.

The use-case for this feature showcased using this example:

```yaml
- uses: pulumi/actions@v3
  name: Preview the shared stack used by all environments
  with:
    command: preview
    stack-name: org-name/shared
    comment-on-pr: true
- uses: pulumi/actions@v3
  name: Preview the stack for the development environment
  with:
    command: preview
    stack-name: org-name/develop
    comment-on-pr: true
```

This workflow currently runs two preview commands but writes the latest output into the comment in the pull-request. By introducing a hidden HTML tag with an unique identifier, the workflow creates multiple comments:

```yaml
- uses: pulumi/actions@v3
  name: Preview the shared stack used by all environments
  with:
    command: preview
    stack-name: org-name/shared
    comment-on-pr: true
    comment-on-pr-id: hidden-shared-stack-id
- uses: pulumi/actions@v3
  name: Preview the stack for the development environment
  with:
    command: preview
    stack-name: org-name/develop
    comment-on-pr: true
    comment-on-pr-id: hidden-develop-stack-id
```