### PR TITLE
Check the pulumi installed is what get-version resolved to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 _(none)_
 
---
+- bug: Fix installation on Windows.
+([#851](https://github.com/pulumi/actions/pull/851))
 
 ## 4.0.0 (2023-19-01)
 


### PR DESCRIPTION
Windows wasn't using the pulumi bin that get-version resolved to, so with just the new error check would fail all runs. So this also fixes the windows install so it actually uses the pulumi downloaded rather than the default pulumi installed on GHA runners.