### PR TITLE
Add a diff summary above the Pulumi output in PR comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 --
 
+## 4.5.0 (2023-06-13)
+
+- feat: Show a brief summary and direct URL to Pulumi UI in PR comments
+
 ## 4.4.0 (2023-06-05)
 
 - feat: Download CLI if preinstalled version has a known issue.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,7 @@
 
 - enhancement: Add `pulumi-version` option to allow pinning the version of the
   CLI [PR](https://github.com/pulumi/actions/pull/661) fixes
-  [#437 ](https://github.com/pulumi/actions/issues/437)
+  [#437](https://github.com/pulumi/actions/issues/437)
 
 ## 3.18.1 (2022-07-07)
 

--- a/src/libs/pr.ts
+++ b/src/libs/pr.ts
@@ -25,7 +25,7 @@ export async function handlePullRequestMessage(
   // Make sure the output isn't empty. If it's not, get the last 100 lines.
   const last100Lines = output.length >= 0 ? output.slice(-100) : '';
 
-  const diffChanges = last100Lines.match(/\~[0-9]+ to update/);
+  const diffUpdates = last100Lines.match(/\~[0-9]+ to update/);
   const diffCreations = last100Lines.match(/\+[0-9]+ to create/);
   const diffDeletions = last100Lines.match(/\-[0-9]+ to delete/);
   const diffUnchanged = last100Lines.match(/[0-9]+ unchanged/);
@@ -38,7 +38,7 @@ export async function handlePullRequestMessage(
   // If certain diffs are absent, they're set to 0 to make output consistent
   const diffSummary = searchPattern.test(last100Lines)
     ? `:red_circle: ${diffDeletions ?? '-0 to delete'},
-       :yellow_circle: ${diffChanges ?? '~0 to update'},
+       :yellow_circle: ${diffUpdates ?? '~0 to update'},
        :green_circle: ${diffCreations ?? '+0 to create'},
        :white_circle: ${diffUnchanged ?? '0 unchanged'}
       `

--- a/src/libs/pr.ts
+++ b/src/libs/pr.ts
@@ -32,7 +32,7 @@ export async function handlePullRequestMessage(
 
   // Regex to match the diff summary
   const searchPattern =
-    /(~|\+|-)?[0-9]+ (to)? (update|create|delete|unchanged)/;
+    /(~|\+|-)?[0-9]+( to)? (update|create|delete|unchanged)/;
 
   // Generate a summary with the changes, if any. If there's none, return an empty string.
   // If certain diffs are absent, they're set to 0 to make output consistent

--- a/src/libs/pr.ts
+++ b/src/libs/pr.ts
@@ -23,7 +23,7 @@ export async function handlePullRequestMessage(
   const rawBody = output.substring(0, 64_000);
 
   // Make sure the output isn't empty. If it's not, get the last 100 lines.
-  const last100Lines = output.length >= 0 ? output.slice(-100) : '';
+  const last100Lines = output.length > 0 ? output.slice(-100) : '';
 
   const diffUpdates = last100Lines.match(/\~[0-9]+ to update/);
   const diffCreations = last100Lines.match(/\+[0-9]+ to create/);

--- a/src/libs/pr.ts
+++ b/src/libs/pr.ts
@@ -21,11 +21,35 @@ export async function handlePullRequestMessage(
   const summary = '<summary>Pulumi report</summary>';
 
   const rawBody = output.substring(0, 64_000);
+
+  // Make sure the output isn't empty. If it's not, get the last 100 lines.
+  const last100Lines = output.length >= 0 ? output.slice(-100) : '';
+
+  const diffChanges = last100Lines.match(/\~[0-9]+ to update/);
+  const diffCreations = last100Lines.match(/\+[0-9]+ to create/);
+  const diffDeletions = last100Lines.match(/\-[0-9]+ to delete/);
+  const diffUnchanged = last100Lines.match(/[0-9]+ unchanged/);
+
+  // Regex to match the diff summary
+  const searchPattern =
+    /(~|\+|-)?[0-9]+ (to)? (update|create|delete|unchanged)/;
+
+  // Generate a summary with the changes, if any. If there's none, return an empty string.
+  // If certain diffs are absent, they're set to 0 to make output consistent
+  const diffSummary = searchPattern.test(last100Lines)
+    ? `:red_circle: ${diffDeletions ?? '-0 to delete'},
+       :yellow_circle: ${diffChanges ?? '~0 to update'},
+       :green_circle: ${diffCreations ?? '+0 to create'},
+       :white_circle: ${diffUnchanged ?? '0 unchanged'}
+      `
+    : '';
+
   // a line break between heading and rawBody is needed
   // otherwise the backticks won't work as intended
   const body = dedent`
     ${heading}
 
+    ${diffSummary}
     <details>
     ${summary}
 


### PR DESCRIPTION
This PR adds a brief summary to PR comment just before the Pulumi output. It includes a URL to view the preview, and a brief summary of all changes.

I think it's useful to see an overall view without having to expand the full output and scroll to the bottom.

With these changes, this is what the new output should look like:
![Screenshot 2023-06-13 at 2 41 14 PM](https://github.com/pulumi/actions/assets/111791304/5cb2a8a5-21e0-421d-8610-d436e69a266c)


My method of finding the diffs and URL involves grabbing the first & last 500 chars of the Pulumi output, then using simple regex to search for changes/additions/deletions among the last 500 chars. This approach should take minimal resources.

If there's a better way to accomplish this or if I've missed something in my changes, please let me know.

Thanks!