### PR TITLE
Prepare changelog for v4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 --
 
+## 4.1.1 (2023-03-31)
+
+- fix: Improve error messages around failed Semver resolution.
+  ([#898](https://github.com/pulumi/actions/pull/898))
+
 ## 4.1.0 (2023-03-08)
 
 - feat: Support install-only mode similar to


### PR DESCRIPTION
This PR prepares for the release of the GHA. The only change is an improvement to debug messaging, so this will be a patch release.