### PR TITLE
feat: Support `exclude-protected` on `destroy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## HEAD (Unreleased)
 
+- feat: Support `exclude-protected` on `destroy`.
+  ([#925](https://github.com/pulumi/actions/pull/925))
+
 --
 
 ## 4.2.1 (2023-04-11)

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The action can be configured with the following arguments:
   control as part of the action if you wish to perform any further tasks with
   that stack.
 
-- `exclude-protected` - (optional) Do not destroy protected resources. Only
+- `exclude-protected` - (optional) Skip destroying protected resources. Only
   valid when `command` is `destroy`.
 
 By default, this action will try to authenticate Pulumi with

--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ The action can be configured with the following arguments:
   control as part of the action if you wish to perform any further tasks with
   that stack.
 
+- `exclude-protected` - (optional) Do not destroy protected resources. Only
+  valid when `command` is `destroy`.
+
 By default, this action will try to authenticate Pulumi with
 [Pulumi Cloud](https://app.pulumi.com/). If you have not specified a
 `PULUMI_ACCESS_TOKEN` then you will need to specify an alternative backend via

--- a/action.yml
+++ b/action.yml
@@ -90,7 +90,7 @@ inputs:
     required: false
     default: 'auto'
   exclude-protected:
-    description: 'Do not destroy protected resources. Only valid when command is destroy.'
+    description: 'Skip destroying protected resources. Only valid when command is destroy.'
     required: false
     default: 'false'
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -89,6 +89,10 @@ inputs:
     description: 'Colorize output. Choices are: always, never, raw, auto'
     required: false
     default: 'auto'
+  exclude-protected:
+    description: 'Do not destroy protected resources. Only valid when command is destroy.'
+    required: false
+    default: 'false'
 outputs:
   output:
     description: Output from running command

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@actions/github": "^5.1.1",
     "@actions/io": "^1.1.3",
     "@actions/tool-cache": "^2.0.1",
-    "@pulumi/pulumi": "3.64.0",
+    "@pulumi/pulumi": "3.65.1",
     "actions-parsers": "^1.0.2",
     "dedent": "^0.7.0",
     "envalid": "^7.3.1",

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -15,6 +15,7 @@ const defaultConfig: Record<string, string> = {
   'expect-no-changes': 'false',
   diff: 'false',
   'target-dependents': 'false',
+  'exclude-protected': 'false',
 };
 
 function setupMockedConfig(config: Record<string, string>) {
@@ -44,6 +45,7 @@ describe('config.ts', () => {
         "options": Object {
           "color": undefined,
           "diff": false,
+          "excludeProtected": false,
           "expectNoChanges": false,
           "message": "",
           "parallel": undefined,

--- a/src/config.ts
+++ b/src/config.ts
@@ -68,6 +68,7 @@ export function makeConfig() {
       color: getUnionInput('color', {
         alternatives: ['always', 'never', 'raw', 'auto'] as const,
       }),
+      excludeProtected: getBooleanInput('exclude-protected'),
     },
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -887,10 +887,10 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
-"@pulumi/pulumi@3.64.0":
-  version "3.64.0"
-  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-3.64.0.tgz#8b599b6bb53dcee935192e154e3cf56ae3b30178"
-  integrity sha512-yKEABPiNqOXAlZcGiBSbYElwDrx82IjDUS07R+K3g05EzEttMN5YKv/NjTZsiSWtOGuGscStJnwEWWCjj4GhGQ==
+"@pulumi/pulumi@3.65.1":
+  version "3.65.1"
+  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-3.65.1.tgz#2e8e1a30ac8f543db9250a5ae771751bcbb50254"
+  integrity sha512-XhyBtrA8dvgpiMt7jTnhIuRKIVQ0e/P89WRcsPdkYpnJVM3dc7YdMrFPZ4ceWrDdbNuNgq/fNOCsnxjo5BM/WA==
   dependencies:
     "@grpc/grpc-js" "^1.3.8"
     "@logdna/tail-file" "^2.0.6"


### PR DESCRIPTION
Support passing the `--exclude-protected` flag to `pulumi destroy`. Requires the latest version of `@pulumi/pulumi` where the option is now available in Automation API (see https://github.com/pulumi/pulumi/pull/12734).

Fixes #628