### PR TITLE
feat: Download CLI if preinstalled version is known bad

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -48,6 +48,35 @@ jobs:
     outputs:
       changed: ${{ steps.changes.outputs.dist }}
 
+  test-install-only-without-removal-of-pre-installed-pulumi:
+    needs: install-and-build
+    if:
+      ${{ needs.install-and-build.outputs.changed == 'true' || github.event_name
+      == 'workflow_dispatch' }}
+    runs-on: ${{ matrix.os }}
+    name: Install-only without removal of pre-installed Pulumi on ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Download dist artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: dist
+          path: dist
+
+      # If no action is specified, just install.
+      - uses: ./
+        env:
+          PULUMI_CONFIG_PASSPHRASE: not-a-secret
+        with:
+          config-map: '{name: {value: my-pet, secret: false}}'
+
+      - run: pulumi version
+
   test-install-only:
     needs: install-and-build
     if:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## HEAD (Unreleased)
 
+- feat: Download CLI if preinstalled version has a known issue.
+  ([#956](https://github.com/pulumi/actions/pull/956))
+
 --
 
 ## 4.3.0 (2023-05-12)


### PR DESCRIPTION
Sometimes a release of the CLI contains a bug that is bad enough that we'd prefer users avoid using that version, to avoid the issue. For example, a bug that could cause stack corruption. We'd like to have a holistic way to "taint" a bad release, but in the meantime, one tactical change is to have the action prefer downloading a more recent version of the CLI if the version that is preinstalled has known issues. For now, the list is hardcoded, but in the future it could be stored in a centralized location that the action could check.

Fixes #955