### PR TITLE
chore: use major version references on GitHub Actions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -331,7 +331,7 @@ jobs:
           name: dist
           path: dist
 
-      - uses: actions/setup-python@v4.6.1
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.9
 


### PR DESCRIPTION
Since we're not maintaining SHAs for our workflows, I don't think we need to keep updating spesific versions either. Major versions should probably be fine.
