### PR TITLE
chore: Use `cache` option in `setup-node` action

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -266,19 +266,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
-
-      - name: Get npm cache directory
-        id: npm-cache-dir
-        run: |
-          echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v3
-        id: npm-cache
-        with:
-          path: ${{ steps.npm-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          cache: npm
 
       - run: npm install
         working-directory: .github/test-stacks/nodejs
@@ -409,22 +397,10 @@ jobs:
           name: dist
           path: dist
 
-      - name: Get npm cache directory
-        id: npm-cache-dir
-        run: |
-          echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v3
-        id: npm-cache
-        with:
-          path: ${{ steps.npm-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
+          cache: npm
 
       - run: npm install
         working-directory: .github/test-stacks/nodejs


### PR DESCRIPTION
## Description

https://github.com/pulumi/actions/pull/990#pullrequestreview-1535187586

Use `cache` option in `setup-node` action.

**AS-IS**

```yaml
- name: Get npm cache directory
  id: npm-cache-dir
  run: |
    echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
- uses: actions/cache@v3
  id: npm-cache
  with:
    path: ${{ steps.npm-cache-dir.outputs.dir }}
    key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
    restore-keys: |
      ${{ runner.os }}-node-
- uses: actions/setup-node@v3
  with:
    node-version: 16.x
```

**TO-BE**

```yaml
- uses: actions/setup-node@v3
  with:
    node-version: 16.x
    cache: npm
```