### PR TITLE
Support for 'stack output' command (reopened)

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -131,7 +131,7 @@ jobs:
     name: Dotnet ${{ matrix.command }} on ${{ matrix.os }}
     strategy:
       matrix:
-        command: [up, refresh, destroy, preview]
+        command: [up, refresh, destroy, preview, output]
         os: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
     steps:
@@ -211,7 +211,7 @@ jobs:
     name: Golang ${{ matrix.command }} on ${{ matrix.os }}
     strategy:
       matrix:
-        command: [up, refresh, destroy, preview]
+        command: [up, refresh, destroy, preview, output]
         os: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
     steps:
@@ -291,7 +291,7 @@ jobs:
     name: NodeJS ${{ matrix.command }} on ${{ matrix.os }}
     strategy:
       matrix:
-        command: [up, refresh, destroy, preview]
+        command: [up, refresh, destroy, preview, output]
         os: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
     steps:
@@ -376,7 +376,7 @@ jobs:
     name: Python ${{ matrix.command }} on ${{ matrix.os }}
     strategy:
       matrix:
-        command: [up, refresh, destroy, preview]
+        command: [up, refresh, destroy, preview, output]
         os: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
     steps:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -57,7 +57,6 @@ jobs:
     name: Install-only without removal of pre-installed Pulumi on ${{ matrix.os }}
     strategy:
       matrix:
-        command: [up, refresh, destroy, preview, output]
         os: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@
 - feat: Add support for output command.
 ([#868](https://github.com/pulumi/actions/issues/868))
 
+- feat: Add support for output command.
+([#868](https://github.com/pulumi/actions/issues/868))
+
 ## 4.0.0 (2023-19-01)
 
 - feat: Update Action runtime to NodeJS 16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - feat: Add Update Plan Functionality
   ([#994](https://github.com/pulumi/actions/pull/994))
 
---
+- feat: Add support for output command.
+  ([#868](https://github.com/pulumi/actions/issues/868)) --
 
 ## 4.4.0 (2023-06-05)
 
@@ -51,15 +52,6 @@
 
 - fix: Fix installation on Windows.
   ([#851](https://github.com/pulumi/actions/pull/851))
-
-- feat: Add support for output command.
-  ([#868](https://github.com/pulumi/actions/issues/868))
-
-- feat: Add support for output command.
-  ([#868](https://github.com/pulumi/actions/issues/868))
-
-- feat: Add support for output command.
-  ([#868](https://github.com/pulumi/actions/issues/868))
 
 ## 4.0.0 (2023-19-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@
 - fix: Fix installation on Windows.
   ([#851](https://github.com/pulumi/actions/pull/851))
 
+- feat: Add support for output command.
+([#868](https://github.com/pulumi/actions/issues/868))
+
 ## 4.0.0 (2023-19-01)
 
 - feat: Update Action runtime to NodeJS 16

--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ This will check out the existing directory and run `pulumi preview`.
 
 The action can be configured with the following arguments:
 
-- `command` (required) - The command to run as part of the action. Accepted
-  values are `up` (update), `refresh`, `destroy`, `preview` and `output`.
+- `command` (optional) - The command to run as part of the action. Accepted
+  values are `up` (alias: update), `refresh`, `destroy`, `preview` and `output`.
+  If unspecified, the action will stop after installing Pulumi.
 
 - `stack-name` (optional) - The name of the stack that Pulumi will be operating
   on. Use the fully quaified org-name/stack-name when operating on a stack

--- a/README.md
+++ b/README.md
@@ -34,9 +34,8 @@ This will check out the existing directory and run `pulumi preview`.
 
 The action can be configured with the following arguments:
 
-- `command` (optional) - The command to run as part of the action. Accepted
-  values are `up` (alias: update), `refresh`, `destroy`, `preview` and `outputs`. If
-  unspecified, the action will stop after installing Pulumi.
+- `command` (required) - The command to run as part of the action. Accepted
+  values are `up` (update), `refresh`, `destroy`, `preview` and `output`.
 
 - `stack-name` (optional) - The name of the stack that Pulumi will be operating
   on. Use the fully quaified org-name/stack-name when operating on a stack

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This will check out the existing directory and run `pulumi preview`.
 The action can be configured with the following arguments:
 
 - `command` (optional) - The command to run as part of the action. Accepted
-  values are `up` (alias: update), `refresh`, `destroy`, and `preview`. If
+  values are `up` (alias: update), `refresh`, `destroy`, `preview` and `outputs`. If
   unspecified, the action will stop after installing Pulumi.
 
 - `stack-name` (optional) - The name of the stack that Pulumi will be operating

--- a/src/main.ts
+++ b/src/main.ts
@@ -98,7 +98,7 @@ const runAction = async (config: Config): Promise<void> => {
       onOutput(stderr);
       return stdout;
     },
-    outputs: () => new Promise(() => '') //do nothing, outputs are fetched anyway afterwards
+    output: () => new Promise(() => '') //do nothing, outputs are fetched anyway afterwards
   };
 
   core.debug(`Running action ${config.command}`);
@@ -111,6 +111,7 @@ const runAction = async (config: Config): Promise<void> => {
 
   for (const [outKey, outExport] of Object.entries(outputs)) {
     core.setOutput(outKey, outExport.value);
+    onOutput(outKey + ' found');
     if (outExport.secret) {
       core.setSecret(outExport.value);
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -98,6 +98,7 @@ const runAction = async (config: Config): Promise<void> => {
       onOutput(stderr);
       return stdout;
     },
+    outputs: () => new Promise(() => '') //do nothing, outputs are fetched anyway afterwards
   };
 
   core.debug(`Running action ${config.command}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -111,7 +111,6 @@ const runAction = async (config: Config): Promise<void> => {
 
   for (const [outKey, outExport] of Object.entries(outputs)) {
     core.setOutput(outKey, outExport.value);
-    onOutput(outKey + ' found');
     if (outExport.secret) {
       core.setSecret(outExport.value);
     }


### PR DESCRIPTION
This PR introduced support for `pulumi stack output` command in addition to the existing ones. 

The reasons for this change are explained in the following issue:
[https://github.com/pulumi/actions/issues/868](https://github.com/pulumi/actions/issues/868)

I've chosen `output` as a name for the command as it reflects the method called by CLI, although internally in the sdk it calls `stack.outputs()`.

As mentioned previously I have issues testing this solution, so I invite you to test it yourself and collaborate on the final solution. I have found no relevant tests nor I can see a good way to unit test it, but I've updated the test workflow.