### PR TITLE
chore: node 20 as default runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ---
 
+## 4.6.0 (2023-10-12)
+
+- chore: node 20 as default runtime
+
 ## 4.5.0 (2023-09-12)
 
 - feat: comment on GitHub step summary.

--- a/action.yml
+++ b/action.yml
@@ -111,5 +111,5 @@ runs:
   #
   # Trying to upgrade in July 2022 broke our users that depend on
   # GitHub Enterprise versions < 3.4
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Hi, 

Node 16 reached the [end of life on Sep, 11 2023](https://nodejs.org/en/blog/announcements/nodejs16-eol). 

Node 20 is supported on GitHub Runners since https://github.com/actions/runner/releases/tag/v2.308.0.

This PR updates the runtime

