### PR TITLE
fix(examples): Updated 'setup-nodejs' actions to 'setup-node'

### DIFF
--- a/examples/nodejs-azure.yaml
+++ b/examples/nodejs-azure.yaml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Node LTS ✨
-        uses: actions/setup-nodejs@v3
+        uses: actions/setup-node@v3
         with:
           node-version: lts/*
           cache: yarn

--- a/examples/nodejs-google-workload-identity-federation.yaml
+++ b/examples/nodejs-google-workload-identity-federation.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Node LTS ✨
-        uses: actions/setup-nodejs@v3
+        uses: actions/setup-node@v3
         with:
           node-version: lts/*
           cache: yarn

--- a/examples/nodejs-google.yaml
+++ b/examples/nodejs-google.yaml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Node LTS ✨
-        uses: actions/setup-nodejs@v3
+        uses: actions/setup-node@v3
         with:
           node-version: lts/*
           cache: yarn

--- a/examples/nodejs-local.yaml
+++ b/examples/nodejs-local.yaml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Node LTS ✨
-        uses: actions/setup-nodejs@v3
+        uses: actions/setup-node@v3
         with:
           node-version: lts/*
           cache: yarn

--- a/examples/nodejs-pulumi.yaml
+++ b/examples/nodejs-pulumi.yaml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Node LTS ✨
-        uses: actions/setup-nodejs@v3
+        uses: actions/setup-node@v3
         with:
           node-version: lts/*
           cache: yarn


### PR DESCRIPTION
This just updates the examples to use the correct GitHub action for setting up node. The repository is https://github.com/actions/setup-node and thus with `actions/setup-nodejs` you will receive the error `Unable to clone https://github.com/actions/setup-nodejs refs/heads/v3: repository not found`