### PR TITLE
Search for pulumi in the tool cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 **(none)**
 
+- feat: Search for pulumi in the tool cache
+  ([#1025](https://github.com/pulumi/actions/pull/1025))
+
 ---
 
 ## 4.6.0 (2023-10-12)


### PR DESCRIPTION
The action already stores pulumi in the tool cache, but doesn't use it on subsequent runs and downloads instead.

Reusing from the tool cache can lead to a significant speedup if other things are already cached on the runner and the stack itself is small.