### PR TITLE
Fix policy-related options in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,12 @@ The action can be configured with the following arguments:
 - `parallel` - (optional) Allow P resource operations to run in parallel at once
   (1 for no parallelism). Defaults to unbounded.
 
-- `policy-pack` - (optional) Run one or more policy packs with the provided
-  `command`
+- `policyPacks` - (optional) Run one or more policy packs with the provided
+  `command`. Multiple values can be specified one per line (example: `<value | string>,...`).
 
-- `policy-pack-config` - (optional) Path(s) to JSON file(s) containing the
-  config for the policy pack with the corresponding "policy-pack" argument
+- `policyPackConfigs` - (optional) Path(s) to JSON file(s) containing the
+  config for the policy pack with the corresponding "policy-pack" argument.
+  Multiple values can be specified one per line (example: `<value | string>,...`).
 
 - `pulumi-version` - (optional) Install a specific version of the Pulumi CLI.
   Defaults to "^3"


### PR DESCRIPTION
The README says to use `policy-pack` and `policy-pack-config`, but these aren't correct based on the implementation. They should be `policyPacks` and `policyPackConfig`.

Fixes #1024