### PR TITLE
feat: debug and verbosity

### DIFF
--- a/.github/test-stacks/dotnet/Program.cs
+++ b/.github/test-stacks/dotnet/Program.cs
@@ -13,6 +13,8 @@ return await Deployment.RunAsync(() =>
 
     var petName = pet.Id;
 
+    Pulumi.Log.Debug("I'm  a random pet", pet);
+
     // Export outputs here
     return new Dictionary<string, object?>
     {

--- a/.github/test-stacks/golang/main.go
+++ b/.github/test-stacks/golang/main.go
@@ -16,6 +16,9 @@ func main() {
 		if err != nil {
 			return err
 		}
+		ctx.Log.Debug("I'm a random string", &pulumi.LogArgs{
+			Resource: s,
+		})
 		ctx.Export("name", s.Result)
 		return nil
 	})

--- a/.github/test-stacks/nodejs/index.ts
+++ b/.github/test-stacks/nodejs/index.ts
@@ -5,4 +5,6 @@ let config = new pulumi.Config();
 let name = config.require("name");
 const pet = new random.RandomPet(name);
 
+pulumi.log.debug("I'm a random pet", pet)
+
 export const petName = pet.id;

--- a/.github/test-stacks/python/__main__.py
+++ b/.github/test-stacks/python/__main__.py
@@ -5,4 +5,6 @@ config = pulumi.Config()
 name = config.require("name")
 random_host_name = random.RandomPet(name)
 
+pulumi.debug("I'm a random pet", random_host_name)
+
 pulumi.export("name", random_host_name.id)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,8 @@ jobs:
           cache: yarn
       - run: yarn install
       - run: yarn build
-      - uses: ./
+      - name: Run Pulumi Up
+        uses: ./
         if: always()
         id: pulumi
         env:
@@ -54,8 +55,12 @@ jobs:
           upsert: true
           work-dir: .github/test-stacks/golang
           config-map: "{name: {value: test, secret: false}}"
+          suppress-progress: true
+          log-verbosity: 6
+          debug: true
       - run: echo 'The random string is `${{ steps.pulumi.outputs.name }}`'
-      - uses: ./
+      - name: Get Outputs
+        uses: ./
         if: always()
         id: pulumioutput
         env:
@@ -108,6 +113,9 @@ jobs:
           work-dir: .github/test-stacks/golang
           config-map: "{name: {value: test, secret: false}}"
           plan: /tmp/update-plan.json
+          suppress-progress: true
+          log-verbosity: 6
+          debug: true
       - name: Apply Update Plan via Pulumi Up
         uses: ./
         if: always()
@@ -122,4 +130,7 @@ jobs:
           work-dir: .github/test-stacks/golang
           config-map: "{name: {value: test, secret: false}}"
           plan: /tmp/update-plan.json
+          suppress-progress: true
+          log-verbosity: 6
+          debug: true
       - run: echo 'The random string is `${{ steps.pulumi-up.outputs.name }}`'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## HEAD (Unreleased)
 
-**(none)**
+- feat: verbosity and debug inputs to enable debug options
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ The action can be configured with the following arguments:
 - `color` - (optional) Colorize output. Choices are: always, never, raw, auto
   (default "auto").
 
+- `log-verbosity` - (optional) Enable verbose logging (1-11; >3 is very
+  verbose).
+
+- `log-flow` - (optional) Flow log settings to child processes (like plugins).
+
+- `debug` - (optional) Print detailed debugging output during resource
+  operations.
+
 ### Extra options
 
 - `config-map` - (optional) Configuration of the stack. Format Yaml string:

--- a/action.yml
+++ b/action.yml
@@ -119,14 +119,16 @@ inputs:
     required: false
     default: 'false'
   log-verbosity:
-    description: 'Log verbosity of CLI during execution 1-10; Anything >3 is very verbose'
+    description: 'Enable verbose logging (1-11; >3 is very verbose)'
     required: false
-  log-to-std-err:
-    description: 'Log to stderr instead of to files'
+  log-flow:
+    description: 'Flow log settings to child processes (like plugins)'
     required: false
+    default: 'false'
   debug:
     description: 'Print detailed debugging output during resource operations'
     required: false
+    default: 'false'
 outputs:
   output:
     description: Output from running command

--- a/action.yml
+++ b/action.yml
@@ -118,6 +118,15 @@ inputs:
     description: 'Continue running the update even if an error is encountered'
     required: false
     default: 'false'
+  log-verbosity:
+    description: 'Log verbosity of CLI during execution 1-10; Anything >3 is very verbose'
+    required: false
+  log-to-std-err:
+    description: 'Log to stderr instead of to files'
+    required: false
+  debug:
+    description: 'Print detailed debugging output during resource operations'
+    required: false
 outputs:
   output:
     description: Output from running command

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -22,6 +22,9 @@ const defaultConfig: Record<string, string> = {
   'suppress-outputs': 'false',
   'suppress-progress': 'false',
   'continue-on-error': 'false',
+  'log-verbosity': '',
+  'log-flow': 'false',
+  'debug': 'false',
 };
 
 function setupMockedConfig(config: Record<string, string>) {
@@ -53,9 +56,13 @@ describe('config.ts', () => {
         "options": Object {
           "color": undefined,
           "continueOnError": false,
+          "debug": false,
           "diff": false,
           "excludeProtected": false,
           "expectNoChanges": false,
+          "logFlow": false,
+          "logToStdErr": false,
+          "logVerbosity": undefined,
           "message": "",
           "parallel": undefined,
           "plan": "",
@@ -200,5 +207,15 @@ describe('config.ts', () => {
     }).toThrow(
       /Only one of 'pulumi-version' or 'pulumi-version-file' should be provided, got both/,
     );
+  });
+
+  it('should log to stderr when log verbosity is set', async () => {
+    setupMockedConfig({
+      ...defaultConfig,
+      'log-verbosity': '9',
+    });
+
+    const c = makeConfig();
+    expect(c.options.logToStdErr).toBe(true);
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -115,6 +115,9 @@ export function makeConfig() {
       suppressOutputs: getBooleanInput('suppress-outputs'),
       suppressProgress: getBooleanInput('suppress-progress'),
       continueOnError: getBooleanInput('continue-on-error'),
+      logVerbosity: getInput('log-verbosity'),
+      logToStdErr: getInput('log-to-std-err'),
+      debug: getInput('debug'),
     },
   };
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -115,9 +115,10 @@ export function makeConfig() {
       suppressOutputs: getBooleanInput('suppress-outputs'),
       suppressProgress: getBooleanInput('suppress-progress'),
       continueOnError: getBooleanInput('continue-on-error'),
-      logVerbosity: getInput('log-verbosity'),
-      logToStdErr: getInput('log-to-std-err'),
-      debug: getInput('debug'),
+      logVerbosity: getNumberInput('log-verbosity'),
+      logFlow: getBooleanInput('log-flow'),
+      logToStdErr: !!getInput('log-verbosity'),  // logToStdErr is true if logVerbosity has a truthy value
+      debug: getBooleanInput('debug'),
     },
   };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -119,7 +119,11 @@ const runAction = async (config: Config): Promise<void> => {
   const [stdout, stderr] = await actions[config.command]();
   core.debug(`Done running action ${config.command}`);
   if (stderr !== '') {
-    core.warning(stderr);
+    if (config.options.logToStdErr) {
+      core.info(stderr);
+    } else {
+      core.warning(stderr);
+    }
   }
 
   core.setOutput('output', stdout);


### PR DESCRIPTION
Adding two optional inputs that are already [supported by @pulumi/automation](https://github.com/pulumi/pulumi/blob/master/sdk/nodejs/automation/stack.ts#L856-L868) 

fixes: https://github.com/pulumi/actions/issues/589


Unfortunately there's no functionality in @pulumi/automation supporting args passing. 