### PR TITLE
allow getting latest dev version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## HEAD (Unreleased)
 
-**(none)**
+- feat: allow installing the latest dev release automatically
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -97,8 +97,7 @@ The action can be configured with the following arguments:
   (1 for no parallelism). Defaults to unbounded.
 
 - `policyPacks` - (optional) Run one or more policy packs with the provided
-  `command`. Multiple values can be specified one per line (example:
-  `<value | string>,...`).
+  `command`. Multiple values can be specified one per line (example: `<value | string>,...`).
 
 - `policyPackConfigs` - (optional) Path(s) to JSON file(s) containing the config
   for the policy pack with the corresponding "policy-pack" argument. Multiple

--- a/README.md
+++ b/README.md
@@ -97,14 +97,16 @@ The action can be configured with the following arguments:
   (1 for no parallelism). Defaults to unbounded.
 
 - `policyPacks` - (optional) Run one or more policy packs with the provided
-  `command`. Multiple values can be specified one per line (example: `<value | string>,...`).
+  `command`. Multiple values can be specified one per line (example:
+  `<value | string>,...`).
 
-- `policyPackConfigs` - (optional) Path(s) to JSON file(s) containing the
-  config for the policy pack with the corresponding "policy-pack" argument.
-  Multiple values can be specified one per line (example: `<value | string>,...`).
+- `policyPackConfigs` - (optional) Path(s) to JSON file(s) containing the config
+  for the policy pack with the corresponding "policy-pack" argument. Multiple
+  values can be specified one per line (example: `<value | string>,...`).
 
 - `pulumi-version` - (optional) Install a specific version of the Pulumi CLI.
-  Defaults to "^3"
+  Defaults to "^3". Allows a "dev" argument to download the latest unreleased
+  version.
 
 - `remove` - (optional) Removes the target stack if all resources are destroyed.
   Used only with `destroy` command.

--- a/src/libs/libs/get-version.ts
+++ b/src/libs/libs/get-version.ts
@@ -21,6 +21,22 @@ export type Version = rt.Static<typeof VersionRt>;
 const VersionsRt = rt.Array(VersionRt);
 
 export async function getVersionObject(range: string): Promise<Version> {
+  if (range == 'dev') {
+    const result = await got('https://www.pulumi.com/latest-dev-version');
+    const version = 'v' + result.body.trim();
+    const date = new Date().toISOString();
+    const downloads = {
+      'linux-x64': `https://get.pulumi.com/releases/sdk/pulumi-${version}-linux-x64.tar.gz`,
+      'linux-arm64': `https://get.pulumi.com/releases/sdk/pulumi-${version}-linux-arm64.tar.gz`,
+      'darwin-x64': `https://get.pulumi.com/releases/sdk/pulumi-${version}-darwin-x64.tar.gz`,
+      'darwin-arm64': `https://get.pulumi.com/releases/sdk/pulumi-${version}-darwin-arm64.tar.gz`,
+      'windows-x64': `https://get.pulumi.com/releases/sdk/pulumi-${version}-windows-x64.zip`,
+    };
+    const checksums = 'https://get.pulumi.com/releases/sdk/pulumi-${version}-checksums.txt';
+    const latest = false;
+    return { version, date, downloads, checksums, latest };
+  }
+
   const result = await got(
     'https://raw.githubusercontent.com/pulumi/docs/master/data/versions.json',
     { responseType: 'json' },

--- a/src/libs/pulumi-cli.ts
+++ b/src/libs/pulumi-cli.ts
@@ -100,7 +100,12 @@ export async function downloadCli(range: string): Promise<void> {
 
   core.info(`Matched version: ${version}`);
 
-  const isUnsupportedVersion = semver.lt(version, '3.0.0');
+  let isUnsupportedVersion;
+  if (range == 'dev') {
+    isUnsupportedVersion = false;
+  } else {
+    isUnsupportedVersion = semver.lt(version, '3.0.0');
+  }
 
   if (isUnsupportedVersion) {
     core.warning(


### PR DESCRIPTION
Add a new "dev" option for the version field, that allows users to install the latest dev release automatically.

Fixes https://github.com/pulumi/actions/issues/1039