### PR TITLE
prepare changelog for 4.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 ## HEAD (Unreleased)
 
-- feat: allow installing the latest dev release automatically
-
 ---
 
-## 4.6.0 (2023-10-12)
+## 4.6.0 (2024-01-02)
 
+- feat: allow installing the latest dev release automatically
+  ([#1051](https://github.com/pulumi/actions/pull/1051))
 - chore: node 20 as default runtime
+  ([#1018](https://github.com/pulumi/actions/pull/1018))
 
 ## 4.5.0 (2023-09-12)
 


### PR DESCRIPTION
Prepare the changelog for the 4.6.0 release.  We already have a changelog entry for 4.6.0, but there was never an actual release for that, so let's re-use that, and include the other changes that have happened since.