### PR TITLE
Group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,14 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
     schedule:
       interval: "daily"
     labels:
@@ -10,6 +18,14 @@ updates:
       - "dependencies"
   - package-ecosystem: "npm"
     directory: "/"
+    groups:
+      npm:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
     schedule:
       interval: "daily"
     ignore:


### PR DESCRIPTION
This repository has version upgrades enabled for dependabot, but each upgrade goes into its own PR which creates a lot of noise.

This PR changes the config so dependabot will group version updates together.

https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/