### PR TITLE
return error when login fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## HEAD (Unreleased)
 
+- fix: error out when login fails
+  ([#1062](https://github.com/pulumi/actions/pull/1062))
+
 ---
 
 ## 5.0.0 (2024-01-02)

--- a/src/libs/pulumi-cli.ts
+++ b/src/libs/pulumi-cli.ts
@@ -36,8 +36,8 @@ export async function getVersion(): Promise<string | undefined> {
   else return undefined;
 }
 
-export async function run(...args: string[]): Promise<void> {
-  await exec.exec(`pulumi`, args, true);
+export async function run(...args: string[]): Promise<exec.ExecResult> {
+  return exec.exec(`pulumi`, args, true);
 }
 
 export function getPlatform(): string | undefined {

--- a/src/login.ts
+++ b/src/login.ts
@@ -1,12 +1,14 @@
 import * as core from '@actions/core';
+import * as exec from './libs/exec';
 import * as pulumiCli from './libs/pulumi-cli';
 
-export const login = async (cloudUrl: string, accessToken: string): Promise<void> => {  
+export const login = async (cloudUrl: string, accessToken: string): Promise<exec.ExecResult> => {
   if (cloudUrl) {
     core.info(`Logging into ${cloudUrl}`);
-    await pulumiCli.run('--non-interactive' ,'login', cloudUrl);
+    return pulumiCli.run('--non-interactive' ,'login', cloudUrl);
   } else if (accessToken !== '') {
     core.info("Logging into the Pulumi Cloud backend.");
-    await pulumiCli.run('--non-interactive', 'login');
+    return pulumiCli.run('--non-interactive', 'login');
   }
+  return Promise.resolve({ success: true, stdout: '', stderr: '' });
 };

--- a/src/login.ts
+++ b/src/login.ts
@@ -2,13 +2,11 @@ import * as core from '@actions/core';
 import * as exec from './libs/exec';
 import * as pulumiCli from './libs/pulumi-cli';
 
-export const login = async (cloudUrl: string, accessToken: string): Promise<exec.ExecResult> => {
+export const login = async (cloudUrl: string): Promise<exec.ExecResult> => {
   if (cloudUrl) {
     core.info(`Logging into ${cloudUrl}`);
     return pulumiCli.run('--non-interactive' ,'login', cloudUrl);
-  } else if (accessToken !== '') {
-    core.info("Logging into the Pulumi Cloud backend.");
-    return pulumiCli.run('--non-interactive', 'login');
   }
-  return Promise.resolve({ success: true, stdout: '', stderr: '' });
+  core.info("Logging into the Pulumi Cloud backend.");
+  return pulumiCli.run('--non-interactive', 'login');
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,7 +42,7 @@ const installOnly = async (config: InstallationConfig): Promise<void> => {
 
 const runAction = async (config: Config): Promise<void> => {
   await pulumiCli.downloadCli(config.pulumiVersion);
-  const result = await login(config.cloudUrl, environmentVariables.PULUMI_ACCESS_TOKEN);
+  const result = await login(config.cloudUrl);
   if (!result.success) {
     throw new Error(result.stderr);
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,7 +42,10 @@ const installOnly = async (config: InstallationConfig): Promise<void> => {
 
 const runAction = async (config: Config): Promise<void> => {
   await pulumiCli.downloadCli(config.pulumiVersion);
-  await login(config.cloudUrl, environmentVariables.PULUMI_ACCESS_TOKEN);
+  const result = await login(config.cloudUrl, environmentVariables.PULUMI_ACCESS_TOKEN);
+  if (!result.success) {
+    throw new Error(result.stderr);
+  }
 
   const workDir = resolve(
     environmentVariables.GITHUB_WORKSPACE,


### PR DESCRIPTION
Currently if the login fails as part of the GitHub action, we just silently ignore that.  This can be very confusing when steps further down the line fail, e.g. with "error: PULUMI_ACCESS_TOKEN must be set for login during non-interactive CLI sessions", even though the user has set the access token.

Instead of just continuing our merry way when the login fails, fail the action and let the user know.

This might be the cause of https://github.com/pulumi/actions/issues/1014.  The symptoms match, though it's unclear if there is anything else going on in that issue.

/cc @hisuwh