### PR TITLE
return a warning instead of an error on login failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## HEAD (Unreleased)
 
+- fix: only warn when login fails instead of erroring
+  ([#1082](https://github.com/pulumi/actions/pull/1062))
+
 ---
 
 ## 5.1.0 (2024-01-24)

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,7 +44,7 @@ const runAction = async (config: Config): Promise<void> => {
   await pulumiCli.downloadCli(config.pulumiVersion);
   const result = await login(config.cloudUrl);
   if (!result.success) {
-    throw new Error(result.stderr);
+    core.warning(`Failed to login to Pulumi service: ${result.stderr}`);
   }
 
   const workDir = resolve(


### PR DESCRIPTION
Aparently `pulumi login` can fail, and yet other pulumi commands that follow can succeed (see https://github.com/pulumi/actions/issues/1081).

Instead of failing outright when login fails, just print a warning, so people are not confused when further errors happen later.

Fixes https://github.com/pulumi/actions/issues/1081