### PR TITLE
Allow suppressing progress dots and outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## HEAD (Unreleased)
 
+- feat: support disabling progress dots and outputs printing
+  (--suppress-progress, --suppress-outputs)
+  ([#116](https://github.com/pulumi/actions/pull/1116))
+
 ---
 
 ## 5.1.1 (2024-01-24)

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ The action can be configured with the following arguments:
   (1 for no parallelism). Defaults to unbounded.
 
 - `policyPacks` - (optional) Run one or more policy packs with the provided
-  `command`. Multiple values can be specified one per line (example: `<value | string>,...`).
+  `command`. Multiple values can be specified one per line (example:
+  `<value | string>,...`).
 
 - `policyPackConfigs` - (optional) Path(s) to JSON file(s) containing the config
   for the policy pack with the corresponding "policy-pack" argument. Multiple
@@ -128,6 +129,12 @@ The action can be configured with the following arguments:
 
 - `exclude-protected` - (optional) Skip destroying protected resources. Only
   valid when `command` is `destroy`.
+
+- `suppress-outputs` - (optional) Suppress display of stack outputs (in case
+  they contain sensitive values).
+
+- `suppress-progress` - (optional) Suppress display of periodic progress dots to
+  limit logs length.
 
 - `plan` - (optional) Used for
   [update plans](https://www.pulumi.com/docs/concepts/update-plans/)

--- a/action.yml
+++ b/action.yml
@@ -100,6 +100,14 @@ inputs:
   plan:
     description: 'Where to either save an Update Plan or read an Update Plan from'
     required: false
+  suppress-outputs:
+    description: 'Suppress display of stack outputs (in case they contain sensitive values).'
+    required: false
+    default: 'false'
+  suppress-progress:
+    description: 'Suppress display of periodic progress dots to limit logs length'
+    required: false
+    default: 'false'
 outputs:
   output:
     description: Output from running command

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@actions/github": "^5.1.1",
     "@actions/io": "^1.1.3",
     "@actions/tool-cache": "^2.0.1",
-    "@pulumi/pulumi": "3.77.1",
+    "@pulumi/pulumi": "3.109.1",
     "actions-parsers": "^1.0.2",
     "dedent": "^0.7.0",
     "envalid": "^7.3.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@actions/github": "^5.1.1",
     "@actions/io": "^1.1.3",
     "@actions/tool-cache": "^2.0.1",
-    "@pulumi/pulumi": "3.109.1",
+    "@pulumi/pulumi": "3.109.0",
     "actions-parsers": "^1.0.2",
     "dedent": "^0.7.0",
     "envalid": "^7.3.1",

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -17,7 +17,9 @@ const defaultConfig: Record<string, string> = {
   diff: 'false',
   'target-dependents': 'false',
   'exclude-protected': 'false',
-  'plan': '',
+  plan: '',
+  'suppress-outputs': 'false',
+  'suppress-progress': 'false',
 };
 
 function setupMockedConfig(config: Record<string, string>) {
@@ -56,6 +58,8 @@ describe('config.ts', () => {
           "policyPackConfigs": Array [],
           "policyPacks": Array [],
           "replace": Array [],
+          "suppressOutputs": false,
+          "suppressProgress": false,
           "target": Array [],
           "targetDependents": false,
           "userAgent": "pulumi/actions@v5",

--- a/src/config.ts
+++ b/src/config.ts
@@ -71,6 +71,8 @@ export function makeConfig() {
       }),
       excludeProtected: getBooleanInput('exclude-protected'),
       plan: getInput('plan'),
+      suppressOutputs: getBooleanInput('suppress-outputs'),
+      suppressProgress: getBooleanInput('suppress-progress'),
     },
   };
 }


### PR DESCRIPTION
Adds support for --suppress-progress and --suppress-outputs parameters of stack up, preview, destroy and refresh.

Requires changes releasesd in the automation api (pulumi/pulumi 3.109 - https://github.com/pulumi/pulumi/pull/15596)

Original issue described here:
fixes #1108 