### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @pulumi/platform


### PR DESCRIPTION
Similar to what we did in `pulumi/pulumi` in https://github.com/pulumi/pulumi/pull/15438, it would be useful to get reviewers auto-assigned whenever there is a new PR created.  Add @pulumi/platform as `CODEOWNERS` here, so the right reviewers get auto-assigned.