### PR TITLE
Improve error message when version resolution fails

### DIFF
--- a/src/libs/pulumi-cli.ts
+++ b/src/libs/pulumi-cli.ts
@@ -175,6 +175,6 @@ export async function downloadCli(range: string): Promise<void> {
   const pulumiVersion = versionExec.stdout.trim();
   core.debug(`Running pulumi verison returned: ${pulumiVersion}`);
   if (!semver.satisfies(pulumiVersion, version)) {
-    throw new Error('Installed version did not satisfy the resolved version');
+    throw new Error(`Installed version ${pulumiVersion} did not satisfy the resolved version ${version}`);
   }
 }


### PR DESCRIPTION
We've hit issues a few times where version resolution failed and it wasn't clear why because the error doesn't report the version returned from `pulumi version`. This adds that version (and the version we're trying for) to the error message to make debugging much easier.