### PR TITLE
Include the versions in the error message

### DIFF
--- a/src/libs/pulumi-cli.ts
+++ b/src/libs/pulumi-cli.ts
@@ -175,6 +175,6 @@ export async function downloadCli(range: string): Promise<void> {
   const pulumiVersion = versionExec.stdout.trim();
   core.debug(`Running pulumi verison returned: ${pulumiVersion}`);
   if (!semver.satisfies(pulumiVersion, version)) {
-    throw new Error('Installed version did not satisfy the resolved version');
+    throw new Error(`Installed version "${pulumiVersion}" did not satisfy the resolved version "${version}"`);
   }
 }


### PR DESCRIPTION
Include the versions in question in the error message when the installed version does not satisfy the resolved version. So we can see what the actual problem is.