### PR TITLE
Add support for OIDC token exchange for authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## HEAD (Unreleased)
 
+- feat: Add support for OIDC token exchange for authentication
+  ([#1155](https://github.com/pulumi/actions/pull/1155))
+
 ---
 
 ## 5.2.1 (2024-04-11)

--- a/README.md
+++ b/README.md
@@ -71,6 +71,30 @@ The action can be configured with the following arguments:
 - `color` - (optional) Colorize output. Choices are: always, never, raw, auto
   (default "auto").
 
+### Using OpenID Connect authentication
+
+For more information regarding the OpenID Connect integration, refer to the
+[Pulumi Documentation](https://www.pulumi.com/docs/pulumi-cloud/oidc/client/).
+
+- `oidc-pulumi-organization`: The name of the organization it will request a
+  token for.
+
+- `oidc-equested-token-type`: Defines the type of token to request:
+
+  - Org token: `urn:pulumi:token-type:access_token:organization`
+  - Team token: `urn:pulumi:token-type:access_token:team` (scope
+    `team:{TEAM_NAME}` is required)
+  - Personal token: `urn:pulumi:token-type:access_token:personal` (scope
+    `user:{USER_LOGIN}` is required)
+
+- `oidc-scope`: When requesting a personal or team token, the
+  [proper scope](https://www.pulumi.com/docs/pulumi-cloud/oidc/client/) should
+  be defined.
+
+- `oidc-token-expiration`: (optional, time in seconds) used to customize the
+  token expiration required by the operation. The default token expiration (2
+  hours) will be used.
+
 ### Extra options
 
 - `config-map` - (optional) Configuration of the stack. Format Yaml string:

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ For more information regarding the OpenID Connect integration, refer to the
 - `oidc-pulumi-organization`: The name of the organization it will request a
   token for.
 
-- `oidc-equested-token-type`: Defines the type of token to request:
+- `oidc-requested-token-type`: Defines the type of token to request:
 
   - Org token: `urn:pulumi:token-type:access_token:organization`
   - Team token: `urn:pulumi:token-type:access_token:team` (scope

--- a/action.yml
+++ b/action.yml
@@ -108,6 +108,18 @@ inputs:
     description: 'Suppress display of periodic progress dots to limit logs length'
     required: false
     default: 'false'
+  oidc-pulumi-organization:
+    description: The organization it will exchange a token for
+    required: false
+  oidc-scope:
+    description: The scope to use when requesting the Pulumi access token
+    required: false
+  oidc-requested-token-type:
+    description: Type of access token to request
+    required: false
+  oidc-token-expiration: 
+    description: Token expiration
+    required: false
 outputs:
   output:
     description: Output from running command

--- a/action.yml
+++ b/action.yml
@@ -123,6 +123,8 @@ inputs:
 outputs:
   output:
     description: Output from running command
+  pulumi-access-token:
+    description: Output of the OIDC token exchance when running on oidc exange mode Only
 runs:
   # TODO upgrade to node16 by 1 Nov 2022.
   #

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@actions/tool-cache": "^2.0.1",
     "@pulumi/pulumi": "3.109.0",
     "actions-parsers": "^1.0.2",
+    "axios": "^1.6.8",
     "dedent": "^0.7.0",
     "envalid": "^7.3.1",
     "got": "^11.8.6",

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -47,12 +47,6 @@ describe('config.ts', () => {
         "configMap": undefined,
         "editCommentOnPr": false,
         "githubToken": "n/a",
-        "oidcAuthentication": Object {
-          "expiration": undefined,
-          "organizationName": "",
-          "requestedTokenType": "",
-          "scope": "",
-        },
         "options": Object {
           "color": undefined,
           "diff": false,

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -47,6 +47,12 @@ describe('config.ts', () => {
         "configMap": undefined,
         "editCommentOnPr": false,
         "githubToken": "n/a",
+        "oidcAuthentication": Object {
+          "expiration": undefined,
+          "organizationName": "",
+          "requestedTokenType": "",
+          "scope": "",
+        },
         "options": Object {
           "color": undefined,
           "diff": false,

--- a/src/config.ts
+++ b/src/config.ts
@@ -108,16 +108,6 @@ export function makeConfig() {
       suppressOutputs: getBooleanInput('suppress-outputs'),
       suppressProgress: getBooleanInput('suppress-progress'),
     },
-    oidcAuthentication: {
-      organizationName: getInput('oidc-pulumi-organization', {
-        required: false,
-      }),
-      scope: getInput('oidc-scope', { required: false }),
-      requestedTokenType: getInput('oidc-requested-token-type', {
-        required: false,
-      }),
-      expiration: getNumberInput('oidc-token-expiration', { required: false }),
-    },
   };
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,7 +33,14 @@ export function makeConfig() {
   return {
     command: getUnionInput('command', {
       required: true,
-      alternatives: ['up', 'update', 'refresh', 'destroy', 'preview', 'output'] as const,
+      alternatives: [
+        'up',
+        'update',
+        'refresh',
+        'destroy',
+        'preview',
+        'output',
+      ] as const,
     }),
     stackName: getInput('stack-name', { required: true }),
     pulumiVersion: getInput('pulumi-version', { required: true }),
@@ -73,6 +80,17 @@ export function makeConfig() {
       plan: getInput('plan'),
       suppressOutputs: getBooleanInput('suppress-outputs'),
       suppressProgress: getBooleanInput('suppress-progress'),
+    },
+
+    oidcAuthentication: {
+      organizationName: getInput('oidc-pulumi-organization', {
+        required: false,
+      }),
+      scope: getInput('oidc-scope', { required: false }),
+      requestedTokenType: getInput('oidc-requested-token-type', {
+        required: false,
+      }),
+      expiration: getNumberInput('oidc-token-expiration', { required: false }),
     },
   };
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -28,6 +28,33 @@ export function makeInstallationConfig(): rt.Result<InstallationConfig> {
   });
 }
 
+// installationConfig is the expected Action inputs when
+// the user intends to fetch a Pulumi access token using
+// a Github OIDC token without
+// running any other Pulumi operations.
+// We expect command NOT to be provided.
+export const oidcLoginConfig = rt.Record({
+  command: rt.String.Or(rt.Undefined),
+  cloudUrl: rt.String.Or(rt.Undefined),
+  organizationName: rt.String,
+  requestedTokenType: rt.String,
+  scope: rt.String.Or(rt.Undefined),
+  expiration: rt.Number.Or(rt.Undefined),
+});
+
+export type OidcLoginConfig = rt.Static<typeof oidcLoginConfig>;
+
+export function makeOidcLoginConfig(): rt.Result<OidcLoginConfig> {
+  return oidcLoginConfig.validate({
+    command: getInput('command') || undefined,
+    organizationName: getInput('oidc-pulumi-organization')|| undefined,
+    scope: getInput('oidc-scope', { required: false }) || undefined,
+    requestedTokenType: getInput('oidc-requested-token-type') || undefined,
+    expiration: getNumberInput('oidc-token-expiration', { required: false }) || undefined,
+    cloudUrl: getInput('cloud-url') || undefined,
+  });
+}
+
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function makeConfig() {
   return {
@@ -81,7 +108,6 @@ export function makeConfig() {
       suppressOutputs: getBooleanInput('suppress-outputs'),
       suppressProgress: getBooleanInput('suppress-progress'),
     },
-
     oidcAuthentication: {
       organizationName: getInput('oidc-pulumi-organization', {
         required: false,

--- a/src/libs/exec.ts
+++ b/src/libs/exec.ts
@@ -14,6 +14,7 @@ export const exec = async (
   const { exitCode, stdout, stderr } = await aexec.getExecOutput(command, args, {
     silent: silent,
     ignoreReturnCode: true,
+    env: process.env,
   });
 
   return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1840,6 +1840,15 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
+axios@^1.6.8:
+  version "1.6.8"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.8.tgz#66d294951f5d988a00e87a0ffb955316a619ea66"
+  integrity sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 babel-jest@^26.6.3:
   version "26.6.3"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-26.6.3.tgz#d87d25cb0037577a0c89f82e5755c5d293c01056"
@@ -3112,6 +3121,11 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.6.tgz#022e9218c637f9f3fc9c35ab9c9193f05add60b2"
   integrity sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==
 
+follow-redirects@^1.15.6:
+  version "1.15.6"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
+  integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
+
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
@@ -3136,6 +3150,15 @@ form-data@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
   integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
@@ -5728,6 +5751,11 @@ protobufjs@^7.2.4:
     "@types/node" ">=13.7.0"
     long "^5.0.0"
 
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
 psl@^1.1.33:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
@@ -6342,7 +6370,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6405,7 +6442,14 @@ string.prototype.trimstart@^1.0.6:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -7030,7 +7074,7 @@ word-wrap@^1.2.3, word-wrap@~1.2.3:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.4.tgz#cb4b50ec9aca570abd1f52f33cd45b6c61739a9f"
   integrity sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -7043,6 +7087,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Two new modes are introduced in this PR:

## Support for OIDC authentication 
If at least `oidc-pulumi-organization` and `oidc-requested-token-type` are configured, it will automatically request a Github OIDC token and exchange it by a Pulumi access token removing the need to hardcode credentials. For more information, check the [OIDC integration docs](https://www.pulumi.com/docs/pulumi-cloud/oidc/client/).

```
name: Pulumi up
on:
  workflow_dispatch:
permissions:
  id-token: write
  contents: read
jobs:
  run_cron_job:
    runs-on: ubuntu-20.04
    timeout-minutes: 30
    steps:
      - name: Checkout repo
        uses: actions/checkout@v3

      - run: yarn

      - uses: pulumi/actions@v4
        with:
          command: up
          stack-name: testagents/gh
          oidc-pulumi-organization: testagents
          oidc-requested-token-type: urn:pulumi:token-type:access_token:organization
```

## New OIDC authentication only
If no pulumi operation is configured, but oidc is, it will exchange the oidc token by a Pulumi access token and exit. It also adds a new `pulumi-access-token` output for other steps to use the Pulumi access token.

```
name: Pulumi oidc auth
on:
  workflow_dispatch:

permissions:
  id-token: write
  contents: read

jobs:
  run_cron_job:
    runs-on: ubuntu-20.04
    timeout-minutes: 30

    steps:
      - name: Checkout repo
        uses: actions/checkout@v3

      - run: yarn

      - uses: pulumi/actions@v4
        id: pulumi
        with:
          oidc-pulumi-organization: testagents
          oidc-requested-token-type: urn:pulumi:token-type:access_token:organization

      - run: PULUMI_ACCESS_TOKEN=${{steps.pulumi.outputs.pulumi-access-token}} pulumi whoami
```