### PR TITLE
prepare for renaming master to main

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "master", "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "master", "main" ]
   schedule:
     - cron: '31 7 * * 6'
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ name: Pulumi
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   up:
     name: Preview


### PR DESCRIPTION
Prepare this repo for switching its main branch name to `main` by making the workflows run on both `master` and `main`.  Some workflows already run that way, but make sure all of them do, ahead of going ahead and renaming it.

Once the branch is renamed, we can drop the build on `master` here.