### PR TITLE
update references from master to main

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "master", "main" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master", "main" ]
+    branches: [ "main" ]
   schedule:
     - cron: '31 7 * * 6'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,6 @@ on: # rebuild any PRs and main branch changes
   push:
     branches:
       - main
-      - master
     paths-ignore:
       - 'CHANGELOG.md'
       - 'README.md'

--- a/.github/workflows/update_dist.yml
+++ b/.github/workflows/update_dist.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - master
 
 jobs:
   update-dist:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - master
     paths-ignore:
       - 'CHANGELOG.md'
       - 'README.md'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ latest release is `v3.18.1`, and you wish to cut `v.3.19.0`.
 1. Checkout the default branch.
 
    ```bash
-   $ git checkout master
+   $ git checkout main
    ```
 
 2. Open up `CHANGELOG.md`. Create a new h2 with the release version and the date
@@ -45,7 +45,7 @@ latest release is `v3.18.1`, and you wish to cut `v.3.19.0`.
 
 3. Commit your changes to `CHANGELOG.md`, and open a PR. Once your changes have
    been approved and status checks have passed, merge your PR into the default
-   branch, `master`.
+   branch, `main`.
 
 4. Wait for status checks on the default branch to pass.
 

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Here are some pointers when migrating from v1 to v2 of our GitHub Action.
 
 - The action now runs natively, so the action workflow needs to have the correct
   environment configured. There are
-  [sample workflows available](https://github.com/pulumi/actions/tree/master/.github/workflows).
+  [sample workflows available](https://github.com/pulumi/actions/tree/main/.github/workflows).
   For examples, if you are running a NodeJS (for example) app then you need to
   ensure that your action has NodeJS available to it:
 


### PR DESCRIPTION
We've renamed `master` to `main`.  Update the branch references from master to main, and remove the references to master in the github actions workflow files.