### PR TITLE
make `comment-on-pr-number` option work even outside of pull-request events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## HEAD (Unreleased)
 
+- fix: `make comment-on-pr-number` option work even outside of pull-request events
+  ([#1178](https://github.com/pulumi/actions/pull/1178))
+
 ---
 
 ## 5.2.1 (2024-04-11)

--- a/src/main.ts
+++ b/src/main.ts
@@ -119,13 +119,12 @@ const runAction = async (config: Config): Promise<void> => {
     }
   }
 
-  if (config.commentOnPrNumber || config.commentOnPr) {
-    const isPullRequest = context.payload.pull_request !== undefined;
-    if (isPullRequest) {
-      core.debug(`Commenting on pull request`);
-      invariant(config.githubToken, 'github-token is missing.');
-      handlePullRequestMessage(config, projectName, output);
-    }
+  const isPullRequest = context.payload.pull_request !== undefined;
+  if (config.commentOnPrNumber ||
+      (config.commentOnPr && isPullRequest)) {
+    core.debug(`Commenting on pull request`);
+    invariant(config.githubToken, 'github-token is missing.');
+    handlePullRequestMessage(config, projectName, output);
   }
 
   if (config.commentOnSummary) {


### PR DESCRIPTION


We only allow the `comment-on-pr` option inside of pull requests. This makes sense because we wouldn't be able to comment on anything otherwise.  However with the `comment-on-pr-number` option gives us a PR number to comment on, so it can make sense with any type of GitHub actions event.  This used to work before #813, and it looks like disallowing this was accidental rather than intentional.

Make this work again.

Fixes #1177