### PR TITLE
upgrade go used in workflows to latest

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -240,7 +240,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.15.x
+          go-version: 1.22.x
 
       - uses: ./
         env:


### PR DESCRIPTION
We're using a very old version of Go here, which apparently can't be installed at least through the GitHub action anymore.  We're not supporting that version since a long time, and there really is no reason why we shouldn't use the latest version of Golang here, so do just that.