### PR TITLE
Document "latest" version specifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,9 @@ The action can be configured with the following arguments:
   values can be specified one per line (example: `<value | string>,...`).
 
 - `pulumi-version` - (optional) Install a specific version of the Pulumi CLI.
-  Defaults to "^3". Allows a "dev" argument to download the latest unreleased
-  version.
+  Defaults to "^3". Specifying a version range will ensure a version within that
+  range is installed. Use "latest" to fetch the latest published release or
+  "dev" to download the latest development pre-release.
 
 - `remove` - (optional) Removes the target stack if all resources are destroyed.
   Used only with `destroy` command.


### PR DESCRIPTION
Closes https://github.com/pulumi/actions/issues/934

This is already implemented here: 
https://github.com/pulumi/actions/blob/042fe5b09b30a1c9ca9c240a776a92f865df1723/src/libs/libs/get-version.ts#L47-L51