### PR TITLE
fix: remove `pulumi-version` default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,6 @@ inputs:
   pulumi-version:
     description: 'Install a specific version of the Pulumi CLI'
     required: false
-    default: '^3'
   pulumi-version-file:
     description: 'File containing the version of the Pulumi CLI to install. Example: .pulumi.version'
     required: false


### PR DESCRIPTION
The default value is conflicting with the new `pulumi-version-file` option. Also, we are defaulting the version in the code here, so we don't need the default to be set by the action.
https://github.com/pulumi/actions/blob/19cc848d9c6fb4ac618050ff0ab3272d1ddec7b4/src/config.ts#L44