### PR TITLE
Add 3.120.0 to the list of known-bad versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## HEAD (Unreleased)
 
+- fix: add 3.120.0 to the list of known-bad versions
+  ((#1210)[https://github.com/pulumi/actions/pull/1210])
+
 ---
 
 ## 5.3.1 (2024-06-25)

--- a/src/libs/pulumi-cli.ts
+++ b/src/libs/pulumi-cli.ts
@@ -19,6 +19,7 @@ function isKnownBadVersion(version: string): boolean {
     '3.66.0',
     '3.67.0',
     '3.67.1',
+    '3.120.0',
   ]);
   return knownBadVersions.has(version);
 }
@@ -174,11 +175,11 @@ export async function downloadCli(range: string): Promise<void> {
   const versionExec = await exec.exec(`pulumi`, ['version'], true);
   const pulumiVersion = versionExec.stdout.trim();
   core.debug(`Running pulumi verison returned: ${pulumiVersion}`);
-  
+
   if (!versionExec.success) {
     throw new Error(`Failed to verify pulumi version:\n${versionExec.stderr}`);
   }
-  
+
   if (!semver.satisfies(pulumiVersion, version)) {
     throw new Error(`Installed version "${pulumiVersion}" did not satisfy the resolved version "${version}"`);
   }


### PR DESCRIPTION
Version 3.120.0 of Pulumi contains a P0 that means `Delete` operations are largely broken. As a result, we'd really like to ensure it's used as little as possible. This commit adds 3.120.0 to the list of "known-bad" versions in the GitHub action, so that we'll force a download of a newer version in the event that 3.120.0 is the default available.