### PR TITLE
make pulumi-version-file also work in non-install mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## HEAD (Unreleased)
 
+- fix: make `pulumi-version-file` work in non-install mode as well
+  ((#1216)[https://github.com/pulumi/actions/pull/1216])
+
 ---
 
 ## 5.3.2 (2024-06-25)

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -87,20 +87,20 @@ describe('config.ts', () => {
   });
 
   it('should return ^3 if pulumi-version is undefined', async () => {
-    jest.mock('@actions/core', () => ({
-      getInput: jest.fn((name: string) => {
-        switch (name) {
-          case 'pulumi-version':
-            return undefined;
-        }
-        return defaultConfig[name];
-      }),
-    }));
+    setupMockedConfig({
+      ...defaultConfig,
+      'pulumi-version': undefined,
+    });
     const conf = makeConfig();
     expect(conf.pulumiVersion).toEqual('^3');
   });
 
   it('should read version from pulumi-version-file', async () => {
+    setupMockedConfig({
+      ...defaultConfig,
+      'pulumi-version': undefined,
+      'pulumi-version-file': '.pulumi.version',
+    });
     jest.mock('fs', () => ({
       ...jest.requireActual('fs'),
       readFileSync: jest.fn((path: string) => {
@@ -111,22 +111,17 @@ describe('config.ts', () => {
         return true;
       }),
     }));
-    jest.mock('@actions/core', () => ({
-      getInput: jest.fn((name: string) => {
-        switch (name) {
-          case 'pulumi-version-file':
-            return '.pulumi.version';
-          case 'pulumi-version':
-            return undefined;
-        }
-        return defaultConfig[name];
-      }),
-    }));
+    const { makeConfig } = require('../config');
     const conf = makeConfig();
     expect(conf.pulumiVersion).toEqual('3.121.0');
   });
 
   it('should fail if pulumi-version-file does not exist', async () => {
+    setupMockedConfig({
+      ...defaultConfig,
+      'pulumi-version': undefined,
+      'pulumi-version-file': '.pulumi.version',
+    });
     jest.mock('fs', () => ({
       ...jest.requireActual('fs'),
       readFileSync: jest.fn((path: string) => {
@@ -137,23 +132,18 @@ describe('config.ts', () => {
         return false;
       }),
     }));
-    jest.mock('@actions/core', () => ({
-      getInput: jest.fn((name: string) => {
-        switch (name) {
-          case 'pulumi-version-file':
-            return '.pulumi.version';
-          case 'pulumi-version':
-            return undefined;
-        }
-        return defaultConfig[name];
-      }),
-    }));
+    const { makeConfig } = require('../config');
     expect(() => {
       makeConfig();
     }).toThrow(/pulumi-version-file '\.pulumi\.version' does not exist/);
   });
 
   it('should fail if pulumi-version-file and pulumi-version are both provided', async () => {
+    setupMockedConfig({
+      ...defaultConfig,
+      'pulumi-version': '^3',
+      'pulumi-version-file': '.pulumi.version',
+    });
     jest.mock('fs', () => ({
       ...jest.requireActual('fs'),
       readFileSync: jest.fn((path: string) => {
@@ -164,15 +154,7 @@ describe('config.ts', () => {
         return false;
       }),
     }));
-    jest.mock('@actions/core', () => ({
-      getInput: jest.fn((name: string) => {
-        if (name === 'pulumi-version-file') {
-          return '.pulumi.version';
-        }
-        return defaultConfig[name];
-      }),
-    }));
-
+    const { makeConfig } = require('../config');
     expect(() => {
       makeConfig();
     }).toThrow(

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -87,20 +87,44 @@ describe('config.ts', () => {
   });
 
   it('should return ^3 if pulumi-version is undefined', async () => {
-    setupMockedConfig({
-      ...defaultConfig,
-      'pulumi-version': undefined,
-    });
+    jest.mock('@actions/core', () => ({
+      getInput: jest.fn((name: string) => {
+        switch (name) {
+          case 'pulumi-version':
+            return undefined;
+        }
+        return defaultConfig[name];
+      }),
+      getBooleanInput: jest.fn((name: string) => {
+        return defaultConfig[name];
+      }),
+      getMultilineInput: jest.fn((name: string) => {
+        return defaultConfig[name];
+      }),
+    }));
+    const { makeConfig } = require('../config');
     const conf = makeConfig();
     expect(conf.pulumiVersion).toEqual('^3');
   });
 
   it('should read version from pulumi-version-file', async () => {
-    setupMockedConfig({
-      ...defaultConfig,
-      'pulumi-version': undefined,
-      'pulumi-version-file': '.pulumi.version',
-    });
+    jest.mock('@actions/core', () => ({
+      getInput: jest.fn((name: string) => {
+        switch (name) {
+          case 'pulumi-version-file':
+            return '.pulumi.version';
+          case 'pulumi-version':
+            return undefined;
+        }
+        return defaultConfig[name];
+      }),
+      getBooleanInput: jest.fn((name: string) => {
+        return defaultConfig[name];
+      }),
+      getMultilineInput: jest.fn((name: string) => {
+        return defaultConfig[name];
+      }),
+    }));
     jest.mock('fs', () => ({
       ...jest.requireActual('fs'),
       readFileSync: jest.fn((path: string) => {
@@ -117,11 +141,17 @@ describe('config.ts', () => {
   });
 
   it('should fail if pulumi-version-file does not exist', async () => {
-    setupMockedConfig({
-      ...defaultConfig,
-      'pulumi-version': undefined,
-      'pulumi-version-file': '.pulumi.version',
-    });
+    jest.mock('@actions/core', () => ({
+      getInput: jest.fn((name: string) => {
+        switch (name) {
+          case 'pulumi-version-file':
+            return '.pulumi.version';
+          case 'pulumi-version':
+            return undefined;
+        }
+        return defaultConfig[name];
+      }),
+    }));
     jest.mock('fs', () => ({
       ...jest.requireActual('fs'),
       readFileSync: jest.fn((path: string) => {
@@ -139,11 +169,17 @@ describe('config.ts', () => {
   });
 
   it('should fail if pulumi-version-file and pulumi-version are both provided', async () => {
-    setupMockedConfig({
-      ...defaultConfig,
-      'pulumi-version': '^3',
-      'pulumi-version-file': '.pulumi.version',
-    });
+    jest.mock('@actions/core', () => ({
+      getInput: jest.fn((name: string) => {
+        switch (name) {
+          case 'pulumi-version-file':
+            return '.pulumi.version';
+          case 'pulumi-version':
+            return '^3';
+        }
+        return defaultConfig[name];
+      }),
+    }));
     jest.mock('fs', () => ({
       ...jest.requireActual('fs'),
       readFileSync: jest.fn((path: string) => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -47,6 +47,22 @@ export function makeInstallationConfig(): rt.Result<InstallationConfig> {
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function makeConfig() {
+  let pulumiVersion = getInput('pulumi-version');
+  const versionFile = getInput('pulumi-version-file');
+  if (pulumiVersion && versionFile) {
+    throw new Error(
+      "Only one of 'pulumi-version' or 'pulumi-version-file' should be provided, got both",
+    );
+  }
+  if (versionFile) {
+    if (fs.existsSync(versionFile)) {
+      pulumiVersion = fs
+        .readFileSync(versionFile, { encoding: 'utf-8' })
+        .trim();
+    } else {
+      throw new Error(`pulumi-version-file '${versionFile}' does not exist`);
+    }
+  }
   return {
     command: getUnionInput('command', {
       required: true,
@@ -60,7 +76,7 @@ export function makeConfig() {
       ] as const,
     }),
     stackName: getInput('stack-name', { required: true }),
-    pulumiVersion: getInput('pulumi-version') ?? '^3',
+    pulumiVersion: pulumiVersion ?? '^3',
     workDir: getInput('work-dir', { required: true }),
     secretsProvider: getInput('secrets-provider'),
     cloudUrl: getInput('cloud-url'),

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,6 +24,9 @@ export type InstallationConfig = rt.Static<typeof installationConfig>;
 
 export function makeInstallationConfig(): rt.Result<InstallationConfig> {
   let pulumiVersion = getInput('pulumi-version');
+  if (pulumiVersion === "undefined") {
+    pulumiVersion = undefined;
+  }
   const versionFile = getInput('pulumi-version-file');
   if (pulumiVersion && versionFile) {
     throw new Error(
@@ -48,6 +51,9 @@ export function makeInstallationConfig(): rt.Result<InstallationConfig> {
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function makeConfig() {
   let pulumiVersion = getInput('pulumi-version');
+  if (pulumiVersion === "undefined") {
+    pulumiVersion = undefined;
+  }
   const versionFile = getInput('pulumi-version-file');
   if (pulumiVersion && versionFile) {
     throw new Error(

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,9 +24,6 @@ export type InstallationConfig = rt.Static<typeof installationConfig>;
 
 export function makeInstallationConfig(): rt.Result<InstallationConfig> {
   let pulumiVersion = getInput('pulumi-version');
-  if (pulumiVersion === "undefined") {
-    pulumiVersion = undefined;
-  }
   const versionFile = getInput('pulumi-version-file');
   if (pulumiVersion && versionFile) {
     throw new Error(
@@ -51,9 +48,6 @@ export function makeInstallationConfig(): rt.Result<InstallationConfig> {
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function makeConfig() {
   let pulumiVersion = getInput('pulumi-version');
-  if (pulumiVersion === "undefined") {
-    pulumiVersion = undefined;
-  }
   const versionFile = getInput('pulumi-version-file');
   if (pulumiVersion && versionFile) {
     throw new Error(


### PR DESCRIPTION
The pulumi-version-file option was introduced in https://github.com/pulumi/actions/pull/1204.  However it was only introduced for installation mode, not if a pulumi command is given. The latter has separate config parsing code, so let's introduce the same option there as well.

Fixes: https://github.com/pulumi/actions/issues/1215