### PR TITLE
update changelog for 5.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 ## HEAD (Unreleased)
 
+**(none)**
+
+---
+
+## 5.3.3 (2024-07-11)
+
 - fix: download latest version only when necessary when 'pulumi-version: latest'
   is specified ((#1225)[https://github.com/pulumi/actions/pull/1225])
 
 - fix: make `pulumi-version-file` work in non-install mode as well
   ((#1216)[https://github.com/pulumi/actions/pull/1216])
-
----
 
 ## 5.3.2 (2024-06-25)
 


### PR DESCRIPTION
Includes the bugfix for making the `pulumi-version-file` option work in non-install mode as well, and a fix for only downloading the latest version when it's actually necessary.