### PR TITLE
only install new pulumi version when there's a newer one available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## HEAD (Unreleased)
 
+- fix: download latest version only when necessary when 'pulumi-version: latest'
+  is specified ((#1225)[https://github.com/pulumi/actions/pull/1225])
+
 - fix: make `pulumi-version-file` work in non-install mode as well
   ((#1216)[https://github.com/pulumi/actions/pull/1216])
 

--- a/src/libs/pulumi-cli.ts
+++ b/src/libs/pulumi-cli.ts
@@ -70,7 +70,7 @@ export async function downloadCli(range: string): Promise<void> {
 
   const isPulumiInstalled = await io.which('pulumi');
 
-  if (isPulumiInstalled) {
+  if (isPulumiInstalled && range != 'latest') {
     // Check for version of Pulumi CLI installed on the runner
     const runnerVersion = await getVersion();
 
@@ -98,6 +98,16 @@ export async function downloadCli(range: string): Promise<void> {
   }
 
   const { version, downloads } = await getVersionObject(range);
+  if (isPulumiInstalled && range === 'latest') {
+    const runnerVersion = await getVersion();
+    if (runnerVersion && runnerVersion === version) {
+      core.info(
+        `Pulumi version ${runnerVersion} is already installed on this machine, and is the latest available. Skipping download`
+      );
+      return;
+    }
+  }
+
 
   core.info(`Matched version: ${version}`);
 


### PR DESCRIPTION
Users can pass 'latest' as the 'pulumi-version' configuration setting. This currently means that they always download the latest version of the CLI, regardless of whether that's already installed or not.

We can do better here and check if the latest version matches the one already installed on the runner, and in that case skip the download.

Fixes https://github.com/pulumi/actions/issues/1221