### PR TITLE
remove unnecessary await

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -29,7 +29,7 @@ const main = async () => {
 
   // If we get here, we're not in install-only mode.
   // Attempt to parse the full configuration and run the action.
-  const config = await makeConfig();
+  const config = makeConfig();
   core.debug('Configuration is loaded');
   runAction(config);
 };


### PR DESCRIPTION
`makeConfig` is not an async function, so the await here has no effect.  Remove it to clean this up.

This is not a necessary change at all, but I need to merge a change to test the config settings I've changed for re-enabling mandatory code reviews for this repo, while also not having the issues mentioned in https://github.com/pulumi/actions/issues/1148.  