### PR TITLE
set PULUMI_BOT_TOKEN when updating dist files

### DIFF
--- a/.github/workflows/update_dist.yml
+++ b/.github/workflows/update_dist.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
 
+env:
+  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+
 jobs:
   update-dist:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We can't make the default GitHub actions user bypass the branch checks.  However we can set up pulumi-bot to be able to do so.  Set GITHUB_TOKEN to PULUMI_BOT_TOKEN, to hopefully make the push from the pulumi-bot user.