### PR TITLE
Trim PR comments from the front.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## HEAD (Unreleased)
 
-_(none)_
+- feat: Trim PR comments from the front
+  ([#1252](https://github.com/pulumi/actions/pull/1252))
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -143,11 +143,16 @@ The action can be configured with the following arguments:
 
 - `plan` - (optional) Used for
   [update plans](https://www.pulumi.com/docs/concepts/update-plans/)
+
   - On `preview`: Where to save the update plan. If you choose to use this in a
     different run of your workflow (let's say you create an update plan via a
     preview on Pull Request creation and want to `up` using the plan) you must
     upload the plan as an artifact, and retrieve it wherever you run `up`
   - On `up`: Where to read the update plan from.
+
+- `trim-comments-from-front` - (optional) If `true`, then the action will trim
+  long pr comments from the front instead of the back. This ensures that the
+  resources summary is always visible.
 
 By default, this action will try to authenticate Pulumi with
 [Pulumi Cloud](https://app.pulumi.com/). If you have not specified a

--- a/README.md
+++ b/README.md
@@ -150,9 +150,9 @@ The action can be configured with the following arguments:
     upload the plan as an artifact, and retrieve it wherever you run `up`
   - On `up`: Where to read the update plan from.
 
-- `trim-comments-from-front` - (optional) If `true`, then the action will trim
+- `always-include-summary` - (optional) If `true`, then the action will trim
   long pr comments from the front instead of the back. This ensures that the
-  resources summary is always visible.
+  resources summary is always included in the comment.
 
 By default, this action will try to authenticate Pulumi with
 [Pulumi Cloud](https://app.pulumi.com/). If you have not specified a

--- a/action.yml
+++ b/action.yml
@@ -110,6 +110,10 @@ inputs:
     description: 'Suppress display of periodic progress dots to limit logs length'
     required: false
     default: 'false'
+  trim-comments-from-front:
+    description: 'If comments must be trimmed, trim them from the front. This ensures the resources summary is included in the comment'
+    required: false
+    default: 'false'
 outputs:
   output:
     description: Output from running command

--- a/action.yml
+++ b/action.yml
@@ -110,8 +110,8 @@ inputs:
     description: 'Suppress display of periodic progress dots to limit logs length'
     required: false
     default: 'false'
-  trim-comments-from-front:
-    description: 'If comments must be trimmed, trim them from the front. This ensures the resources summary is included in the comment'
+  always-include-summary:
+    description: 'If comments must be trimmed, trim them from the front. This ensures the resources summary is always included in the comment'
     required: false
     default: 'false'
 outputs:

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -9,6 +9,7 @@ const defaultConfig: Record<string, string> = {
   'pulumi-version': '^3',
   'comment-on-pr': 'false',
   'comment-on-summary': 'false',
+  'trim-comments-from-front': 'false',
   upsert: 'false',
   remove: 'false',
   refresh: 'false',
@@ -69,6 +70,7 @@ describe('config.ts', () => {
         "remove": false,
         "secretsProvider": "",
         "stackName": "dev",
+        "trimCommentsFromFront": false,
         "upsert": false,
         "workDir": "./",
       }

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -9,7 +9,7 @@ const defaultConfig: Record<string, string> = {
   'pulumi-version': '^3',
   'comment-on-pr': 'false',
   'comment-on-summary': 'false',
-  'trim-comments-from-front': 'false',
+  'always-include-summary': 'false',
   upsert: 'false',
   remove: 'false',
   refresh: 'false',
@@ -40,6 +40,7 @@ describe('config.ts', () => {
     expect(c).toBeTruthy();
     expect(c).toMatchInlineSnapshot(`
       Object {
+        "alwaysIncludeSummary": false,
         "cloudUrl": "file://~",
         "command": "up",
         "commentOnPr": false,
@@ -70,7 +71,6 @@ describe('config.ts', () => {
         "remove": false,
         "secretsProvider": "",
         "stackName": "dev",
-        "trimCommentsFromFront": false,
         "upsert": false,
         "workDir": "./",
       }
@@ -199,5 +199,4 @@ describe('config.ts', () => {
       /Only one of 'pulumi-version' or 'pulumi-version-file' should be provided, got both/,
     );
   });
-
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -92,6 +92,7 @@ export function makeConfig() {
     // @see https://github.com/pulumi/actions/pull/912
     configMap: getYAMLInput<ConfigMap>('config-map'),
     editCommentOnPr: getBooleanInput('edit-pr-comment'),
+    trimCommentsFromFront: getBooleanInput('trim-comments-from-front'),
 
     options: {
       parallel: getNumberInput('parallel', {}),

--- a/src/config.ts
+++ b/src/config.ts
@@ -92,7 +92,7 @@ export function makeConfig() {
     // @see https://github.com/pulumi/actions/pull/912
     configMap: getYAMLInput<ConfigMap>('config-map'),
     editCommentOnPr: getBooleanInput('edit-pr-comment'),
-    trimCommentsFromFront: getBooleanInput('trim-comments-from-front'),
+    alwaysIncludeSummary: getBooleanInput('always-include-summary'),
 
     options: {
       parallel: getNumberInput('parallel', {}),

--- a/src/libs/__tests__/pr.test.ts
+++ b/src/libs/__tests__/pr.test.ts
@@ -144,7 +144,7 @@ describe('pr.ts', () => {
 
     const call = createComment.mock.calls[0][0];
     expect(call.body.length).toBeLessThan(65_536);
-    expect(call.body).toContain('The output was too long and trimmed');
+    expect(call.body).toContain('The output was too long and trimmed.');
   });
 
   it('should trim the output from front when the output is larger than 64k characters and config is set', async () => {
@@ -173,7 +173,7 @@ describe('pr.ts', () => {
     const call = createComment.mock.calls[0][0];
     expect(call.body.length).toBeLessThan(65_536);
     expect(call.body).toContain('this is at the end and should be in the output');
-    expect(call.body).toContain('The output was too long and trimmed from the front');
+    expect(call.body).toContain('The output was too long and trimmed from the front.');
   });
 
   it('should edit the comment if it finds a previous created one', async () => {

--- a/src/libs/__tests__/pr.test.ts
+++ b/src/libs/__tests__/pr.test.ts
@@ -158,15 +158,15 @@ describe('pr.ts', () => {
         },
       },
     };
-    const trimFromFrontOptions = {
+    const alwaysIncludeSummaryOptions = {
       command: 'preview',
       stackName: 'staging',
-      trimCommentsFromFront: true,
+      alwaysIncludeSummary: true,
       options: {},
     } as Config;
 
     await handlePullRequestMessage(
-      trimFromFrontOptions,
+      alwaysIncludeSummaryOptions,
       projectName,
       'a'.repeat(65_000) + '\n' + 'this is at the end and should be in the output',
     );

--- a/src/libs/__tests__/pr.test.ts
+++ b/src/libs/__tests__/pr.test.ts
@@ -50,7 +50,7 @@ describe('pr.ts', () => {
 
     await handlePullRequestMessage(defaultOptions, projectName, 'test');
     expect(createComment).toHaveBeenCalledWith({
-      body: '#### :tropical_drink: `preview` on myFirstProject/staging\n\n<details>\n<summary>Pulumi report</summary>\n\n<pre>\ntest\n</pre>\n\n</details>',
+      body: '#### :tropical_drink: `preview` on myFirstProject/staging\n\n<details>\n<summary>Pulumi report</summary>\n\n\n<pre>\ntest\n</pre>\n\n</details>',
       issue_number: 123,
     });
   });
@@ -69,7 +69,7 @@ describe('pr.ts', () => {
 
     await handlePullRequestMessage(defaultOptions, projectName, '\x1b[30mblack\x1b[37mwhite');
     expect(createComment).toHaveBeenCalledWith({
-      body: '#### :tropical_drink: `preview` on myFirstProject/staging\n\n<details>\n<summary>Pulumi report</summary>\n\n<pre>\n<span style="color:#000">black<span style="color:#AAA">white</span></span>\n</pre>\n\n</details>',
+      body: '#### :tropical_drink: `preview` on myFirstProject/staging\n\n<details>\n<summary>Pulumi report</summary>\n\n\n<pre>\n<span style="color:#000">black<span style="color:#AAA">white</span></span>\n</pre>\n\n</details>',
       issue_number: 123,
     });
   });
@@ -93,7 +93,7 @@ describe('pr.ts', () => {
 
     await handlePullRequestMessage(options, projectName, 'test');
     expect(createComment).toHaveBeenCalledWith({
-      body: '#### :tropical_drink: `preview` on myFirstProject/staging\n\n<details>\n<summary>Pulumi report</summary>\n\n<pre>\ntest\n</pre>\n\n</details>',
+      body: '#### :tropical_drink: `preview` on myFirstProject/staging\n\n<details>\n<summary>Pulumi report</summary>\n\n\n<pre>\ntest\n</pre>\n\n</details>',
       issue_number: 87,
     });
   });
@@ -120,7 +120,7 @@ describe('pr.ts', () => {
 
     await handlePullRequestMessage(options, projectName, 'test');
     expect(createComment).toHaveBeenCalledWith({
-      body: '#### :tropical_drink: `preview` on myFirstProject/staging\n\n<details>\n<summary>Pulumi report</summary>\n\n<pre>\ntest\n</pre>\n\n</details>',
+      body: '#### :tropical_drink: `preview` on myFirstProject/staging\n\n<details>\n<summary>Pulumi report</summary>\n\n\n<pre>\ntest\n</pre>\n\n</details>',
       issue_number: 87,
     });
   });
@@ -192,7 +192,7 @@ describe('pr.ts', () => {
     await handlePullRequestMessage(options, projectName, 'test');
     expect(updateComment).toHaveBeenCalledWith({
       comment_id: 2,
-      body: '#### :tropical_drink: `preview` on myFirstProject/staging\n\n<details>\n<summary>Pulumi report</summary>\n\n<pre>\ntest\n</pre>\n\n</details>',
+      body: '#### :tropical_drink: `preview` on myFirstProject/staging\n\n<details>\n<summary>Pulumi report</summary>\n\n\n<pre>\ntest\n</pre>\n\n</details>',
     });
   });
 });

--- a/src/libs/__tests__/pr.test.ts
+++ b/src/libs/__tests__/pr.test.ts
@@ -145,6 +145,7 @@ describe('pr.ts', () => {
     const call = createComment.mock.calls[0][0];
     expect(call.body.length).toBeLessThan(65_536);
     expect(call.body).toContain('The output was too long and trimmed.');
+    expect(call.body).not.toContain('The output was too long and trimmed from the front.');
   });
 
   it('should trim the output from front when the output is larger than 64k characters and config is set', async () => {
@@ -174,6 +175,7 @@ describe('pr.ts', () => {
     expect(call.body.length).toBeLessThan(65_536);
     expect(call.body).toContain('this is at the end and should be in the output');
     expect(call.body).toContain('The output was too long and trimmed from the front.');
+    expect(call.body).not.toContain('The output was too long and trimmed.');
   });
 
   it('should edit the comment if it finds a previous created one', async () => {

--- a/src/libs/pr.ts
+++ b/src/libs/pr.ts
@@ -8,13 +8,13 @@ import { Config } from '../config';
 function ansiToHtml(
   message: string,
   maxLength: number,
-  trimCommentsFromFront: boolean,
+  alwaysIncludeSummary: boolean,
 ): [string, boolean] {
   /**
    *  Converts an ansi string to html by for example removing color escape characters.
    *  message: ansi string to convert
    *  maxLength: Maximum number of characters of final message incl. HTML tags
-   *  trimCommentsFromFront: if true, trim message from front (if trimming is needed), otherwise from end
+   *  alwaysIncludeSummary: if true, trim message from front (if trimming is needed), otherwise from end
    *
    *  return message as html and information if message was trimmed because of length
    */
@@ -29,7 +29,7 @@ function ansiToHtml(
     // trim input message by number of exceeded characters from front or back as configured
     const dif: number = htmlBody.length - maxLength;
 
-    if (trimCommentsFromFront) {
+    if (alwaysIncludeSummary) {
       message = message.substring(dif, htmlBody.length);
     } else {
       message = message.substring(0, message.length - dif);
@@ -54,7 +54,7 @@ export async function handlePullRequestMessage(
     command,
     stackName,
     editCommentOnPr,
-    trimCommentsFromFront,
+    alwaysIncludeSummary,
   } = config;
 
   // GitHub limits comment characters to 65535, use lower max to keep buffer for variable values
@@ -64,7 +64,7 @@ export async function handlePullRequestMessage(
 
   const summary = '<summary>Pulumi report</summary>';
 
-  const [htmlBody, trimmed]: [string, boolean] = ansiToHtml(output, MAX_CHARACTER_COMMENT, trimCommentsFromFront);
+  const [htmlBody, trimmed]: [string, boolean] = ansiToHtml(output, MAX_CHARACTER_COMMENT, alwaysIncludeSummary);
 
   const body = dedent`
     ${heading}
@@ -72,14 +72,14 @@ export async function handlePullRequestMessage(
     <details>
     ${summary}
 
-    ${trimCommentsFromFront
+    ${alwaysIncludeSummary
       ? ':warning: **Warn**: The output was too long and trimmed from the front.'
       : ''
     }
     <pre>
     ${htmlBody}
     </pre>
-    ${trimmed && !trimCommentsFromFront
+    ${trimmed && !alwaysIncludeSummary
       ? ':warning: **Warn**: The output was too long and trimmed.'
       : ''
     }

--- a/src/libs/pr.ts
+++ b/src/libs/pr.ts
@@ -26,7 +26,7 @@ function ansiToHtml(
 
     // trim input message by number of exceeded characters
     const dif: number = htmlBody.length - maxLength;
-    message = message.substring(0, message.length - dif);
+    message = message.substring(dif, htmlBody.length);
     trimmed = true;
 
     // convert trimmed message to html
@@ -68,7 +68,7 @@ export async function handlePullRequestMessage(
     </pre>
     ${
       trimmed
-        ? ':warning: **Warn**: The output was too long and trimmed.'
+        ? ':warning: **Warn**: The output was too long and trimmed from the front.'
         : ''
     }
     </details>

--- a/src/libs/pr.ts
+++ b/src/libs/pr.ts
@@ -71,6 +71,7 @@ export async function handlePullRequestMessage(
 
     <details>
     ${summary}
+
     ${trimCommentsFromFront
       ? ':warning: **Warn**: The output was too long and trimmed from the front.'
       : ''

--- a/src/libs/pr.ts
+++ b/src/libs/pr.ts
@@ -72,14 +72,14 @@ export async function handlePullRequestMessage(
     <details>
     ${summary}
     ${trimCommentsFromFront
-      ? 'warning: **Warn**: The output was too long and trimmed from the front.'
+      ? ':warning: **Warn**: The output was too long and trimmed from the front.'
       : ''
     }
     <pre>
     ${htmlBody}
     </pre>
-    ${trimmed || (trimmed && !trimCommentsFromFront)
-      ? 'warning: **Warn**: The output was too long and trimmed.'
+    ${trimmed && !trimCommentsFromFront
+      ? ':warning: **Warn**: The output was too long and trimmed.'
       : ''
     }
     </details>

--- a/src/libs/pr.ts
+++ b/src/libs/pr.ts
@@ -30,8 +30,7 @@ function ansiToHtml(
     const dif: number = htmlBody.length - maxLength;
 
     if (trimCommentsFromFront) {
-      const frontTrimmedMessage = 'warning: **Warn**: The output was too long and trimmed from the front.\n';
-      message = frontTrimmedMessage + message.substring(dif, htmlBody.length);
+      message = message.substring(dif, htmlBody.length);
     } else {
       message = message.substring(0, message.length - dif);
     }
@@ -67,23 +66,20 @@ export async function handlePullRequestMessage(
 
   const [htmlBody, trimmed]: [string, boolean] = ansiToHtml(output, MAX_CHARACTER_COMMENT, trimCommentsFromFront);
 
-  let trimmedMessage = 'warning: **Warn**: The output was too long and trimmed.';
-  if (trimCommentsFromFront) {
-    // trimmedMessage is empty because we put it at the beginning of htmlBody
-    trimmedMessage = '';
-  }
-
   const body = dedent`
     ${heading}
 
     <details>
     ${summary}
-
+    ${trimCommentsFromFront
+      ? 'warning: **Warn**: The output was too long and trimmed from the front.'
+      : ''
+    }
     <pre>
     ${htmlBody}
     </pre>
-    ${trimmed
-      ? `${trimmedMessage}`
+    ${trimmed || (trimmed && !trimCommentsFromFront)
+      ? 'warning: **Warn**: The output was too long and trimmed.'
       : ''
     }
     </details>


### PR DESCRIPTION
I believe that the resources summary is the most important component of the output provided by pulumi preview and should always be included in the pull request comment. When trimming from the back, long outputs will not contain this information, which requires navigating to the checks tab and looking at the output there. 

Perhaps this is just a reflection of how I use pulumi but don't think so because we are all conditioned by the local use of the pulumi cli. When we run pulumi preview locally the output ends up right at the bottom so the first thing we see is the summary something like this:
```
Resources:
      ~ 85 to update
      +-26 to replace
      111 changes. 1062 unchanged
```
In many cases this is all the information that is needed to confirm that I'm ready to run pulumi up. Other times I need to look more closely at the details for each resource but even still I have the information from that summary to give me an idea of what I'm looking at as I scroll back through the output.

This change trims the PR comment from the front if it is ever so long that it must be trimmed.

