### PR TITLE
only log warning if output is actually trimmed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## HEAD (Unreleased)
 
+- fix: `always-include-summary` only logs warning when ouput is too large
+  ([#1263](https://github.com/pulumi/actions/pull/1263))
+
 ---
 
 ## 5.5.0 (2024-08-22)

--- a/src/libs/pr.ts
+++ b/src/libs/pr.ts
@@ -72,7 +72,7 @@ export async function handlePullRequestMessage(
     <details>
     ${summary}
 
-    ${alwaysIncludeSummary
+    ${trimmed && alwaysIncludeSummary
       ? ':warning: **Warn**: The output was too long and trimmed from the front.'
       : ''
     }


### PR DESCRIPTION
Fixing small issue where the warning message would always be added to the commit message if `always-include-summary` was set to `true`. This fixes it so it only shows when the output is trimmed.