### PR TITLE
prepare the changelog for the 6.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## 6.0.0 (2024-09-09)
 
-- feat: (breaking change) Update the `refresh` option to runcommands with the
+- feat: (breaking change) Update the `refresh` option to run commands with the
   `--refresh` flag. ([#1118](https://github.com/pulumi/actions/pull/1118))
 
 ## 5.5.1 (2024-08-23)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## HEAD (Unreleased)
 
+---
+
+## 6.0.0 (2024-09-09)
+
 - feat: (breaking change) Update the `refresh` option to runcommands with the
   `--refresh` flag. ([#1118](https://github.com/pulumi/actions/pull/1118))
-
----
 
 ## 5.5.1 (2024-08-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ---
 
-## 6.0.0 (2024-09-09)
+## 6.0.0 (2024-09-27)
 
 - feat: (breaking change) Update the `refresh` option to run commands with the
   `--refresh` flag. ([#1118](https://github.com/pulumi/actions/pull/1118))


### PR DESCRIPTION
This includes a breaking change from https://github.com/pulumi/actions/pull/1118, so we should release a new major version.