### PR TITLE
upgrade @pulumi/pulumi to 3.134.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@actions/github": "^5.1.1",
     "@actions/io": "^1.1.3",
     "@actions/tool-cache": "^2.0.1",
-    "@pulumi/pulumi": "3.109.0",
+    "@pulumi/pulumi": "3.134.0",
     "actions-parsers": "^1.0.2",
     "ansi-to-html": "^0.7.2",
     "dedent": "^0.7.0",


### PR DESCRIPTION
This includes https://github.com/pulumi/pulumi/pull/17209, which we need to fully support the changes made in https://github.com/pulumi/actions/pull/1118, and thus the 6.0.0 release of the pulumi action.