### PR TITLE
add workflow for publishing immutable actions

### DIFF
--- a/.github/workflows/immutable-action.yml
+++ b/.github/workflows/immutable-action.yml
@@ -1,0 +1,23 @@
+name: "Publish Immutable Action Version"
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Publish
+        id: publish
+        uses: actions/publish-immutable-action@v0.0.4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We're switching over to publishing immutable actions from this repo. For this we need to make sure that immutable actions are published at each release of this repo.

With this, we can keep following our current release process, and whenever a new release is published, this action will create a new immutable actions package, that will then be available to users.

(This should only be merged after the current migration process (see https://github.com/pulumi/actions/actions/workflows/immutable-actions-migration/migrate_release) is completed, so that packages will always be in the right order.  Though it wouldn't be a big deal if they were out of order either.  Cosmetically it's nicer if they are in order though)

Fixes https://github.com/pulumi/home/issues/3695