### PR TITLE
Remove ANSI control chars from GitHub step Summary and PR comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - fix: Make `pulumi login` respect configuration in `Pulumi.yaml`
   ([#1299](https://github.com/pulumi/actions/pull/1299))
+- feat: Strip ansi control characters from GitHub step Summary and PR comment
+  ([]())
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 ## HEAD (Unreleased)
 
-**(none)**
-
----
+- feat: Strip ansi control characters from GitHub step Summary and PR comment
+  ([#1312](https://github.com/pulumi/actions/pull/1312))
 
 ## 6.2.0 (2025-03-05)
 
@@ -20,8 +19,6 @@
 
 - fix: Make `pulumi login` respect configuration in `Pulumi.yaml`
   ([#1299](https://github.com/pulumi/actions/pull/1299))
-- feat: Strip ansi control characters from GitHub step Summary and PR comment
-  ([#1312](https://github.com/pulumi/actions/pull/1312))
 
 - fix: Log stderr from commands
   ([#1316](https://github.com/pulumi/actions/issues/1316))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - fix: Make `pulumi login` respect configuration in `Pulumi.yaml`
   ([#1299](https://github.com/pulumi/actions/pull/1299))
 - feat: Strip ansi control characters from GitHub step Summary and PR comment
-  ([]())
+  ([#1312](https://github.com/pulumi/actions/pull/1312))
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "@actions/tool-cache": "^2.0.1",
     "@pulumi/pulumi": "3.134.0",
     "actions-parsers": "^1.0.2",
-    "strip-ansi": "^7.1.0",
     "dedent": "^0.7.0",
     "envalid": "^7.3.1",
     "got": "^11.8.6",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@actions/tool-cache": "^2.0.1",
     "@pulumi/pulumi": "3.134.0",
     "actions-parsers": "^1.0.2",
-    "ansi-to-html": "^0.7.2",
+    "strip-ansi": "^7.1.0",
     "dedent": "^0.7.0",
     "envalid": "^7.3.1",
     "got": "^11.8.6",

--- a/src/libs/__tests__/pr.test.ts
+++ b/src/libs/__tests__/pr.test.ts
@@ -69,7 +69,7 @@ describe('pr.ts', () => {
 
     await handlePullRequestMessage(defaultOptions, projectName, '\x1b[30mblack\x1b[37mwhite');
     expect(createComment).toHaveBeenCalledWith({
-      body: '#### :tropical_drink: `preview` on myFirstProject/staging\n\n<details>\n<summary>Pulumi report</summary>\n\n\n<pre>\n<span style="color:#000">black<span style="color:#AAA">white</span></span>\n</pre>\n\n</details>',
+      body: '#### :tropical_drink: `preview` on myFirstProject/staging\n\n<details>\n<summary>Pulumi report</summary>\n\n\n<pre>\nblackwhite\n</pre>\n\n</details>',
       issue_number: 123,
     });
   });

--- a/src/libs/__tests__/pr.test.ts
+++ b/src/libs/__tests__/pr.test.ts
@@ -50,12 +50,12 @@ describe('pr.ts', () => {
 
     await handlePullRequestMessage(defaultOptions, projectName, 'test');
     expect(createComment).toHaveBeenCalledWith({
-      body: '#### :tropical_drink: `preview` on myFirstProject/staging\n\n<details>\n<summary>Pulumi report</summary>\n\n\n<pre>\ntest\n</pre>\n\n</details>',
+      body: `#### :tropical_drink: \`preview\` on ${projectName}/${defaultOptions.stackName}\n\n<details>\n<summary>Pulumi report</summary>\n\n\n<pre>\ntest\n</pre>\n\n</details>`,
       issue_number: 123,
     });
   });
 
-  it('should convert ansi control character to html and add to pull request message', async () => {
+  it('should convert ansi control character to plain text and add to pull request message', async () => {
     // @ts-ignore
     gh.context = {
       payload: {
@@ -69,7 +69,7 @@ describe('pr.ts', () => {
 
     await handlePullRequestMessage(defaultOptions, projectName, '\x1b[30mblack\x1b[37mwhite');
     expect(createComment).toHaveBeenCalledWith({
-      body: '#### :tropical_drink: `preview` on myFirstProject/staging\n\n<details>\n<summary>Pulumi report</summary>\n\n\n<pre>\nblackwhite\n</pre>\n\n</details>',
+      body: `#### :tropical_drink: \`preview\` on ${projectName}/${defaultOptions.stackName}\n\n<details>\n<summary>Pulumi report</summary>\n\n\n<pre>\nblackwhite\n</pre>\n\n</details>`,
       issue_number: 123,
     });
   });
@@ -93,7 +93,7 @@ describe('pr.ts', () => {
 
     await handlePullRequestMessage(options, projectName, 'test');
     expect(createComment).toHaveBeenCalledWith({
-      body: '#### :tropical_drink: `preview` on myFirstProject/staging\n\n<details>\n<summary>Pulumi report</summary>\n\n\n<pre>\ntest\n</pre>\n\n</details>',
+      body: `#### :tropical_drink: \`preview\` on ${projectName}/${options.stackName}\n\n<details>\n<summary>Pulumi report</summary>\n\n\n<pre>\ntest\n</pre>\n\n</details>`,
       issue_number: 87,
     });
   });
@@ -120,7 +120,7 @@ describe('pr.ts', () => {
 
     await handlePullRequestMessage(options, projectName, 'test');
     expect(createComment).toHaveBeenCalledWith({
-      body: '#### :tropical_drink: `preview` on myFirstProject/staging\n\n<details>\n<summary>Pulumi report</summary>\n\n\n<pre>\ntest\n</pre>\n\n</details>',
+      body: `#### :tropical_drink: \`preview\` on ${projectName}/${options.stackName}\n\n<details>\n<summary>Pulumi report</summary>\n\n\n<pre>\ntest\n</pre>\n\n</details>`,
       issue_number: 87,
     });
   });
@@ -158,15 +158,14 @@ describe('pr.ts', () => {
         },
       },
     };
-    const alwaysIncludeSummaryOptions = {
-      command: 'preview',
-      stackName: 'staging',
+
+    const options: Config = {
+      ...defaultOptions,
       alwaysIncludeSummary: true,
-      options: {},
-    } as Config;
+    };
 
     await handlePullRequestMessage(
-      alwaysIncludeSummaryOptions,
+      options,
       projectName,
       'a'.repeat(65_000) + '\n' + 'this is at the end and should be in the output',
     );
@@ -182,17 +181,16 @@ describe('pr.ts', () => {
     // @ts-ignore
     gh.context = { repo: {} };
 
-    const options = {
-      command: 'preview',
-      stackName: 'staging',
+    const options: Config = {
+      ...defaultOptions,
       commentOnPrNumber: 123,
       editCommentOnPr: true,
-    } as Config;
+    };
 
     await handlePullRequestMessage(options, projectName, 'test');
     expect(updateComment).toHaveBeenCalledWith({
       comment_id: 2,
-      body: '#### :tropical_drink: `preview` on myFirstProject/staging\n\n<details>\n<summary>Pulumi report</summary>\n\n\n<pre>\ntest\n</pre>\n\n</details>',
+      body: `#### :tropical_drink: \`preview\` on ${projectName}/${options.stackName}\n\n<details>\n<summary>Pulumi report</summary>\n\n\n<pre>\ntest\n</pre>\n\n</details>`,
     });
   });
 });

--- a/src/libs/__tests__/summary.test.ts
+++ b/src/libs/__tests__/summary.test.ts
@@ -73,8 +73,8 @@ describe('summary.ts', () => {
   })
 
   it('should trim the output from front when the output is larger than 1 MiB and config is set', async () => {
-    const message = '😄begin' + 'a'.repeat(65_536) + 'this is at the end and should be in the output';
-    const expected = `<h1>Pulumi ${projectName}/${defaultOptions.stackName} results</h1>\n<pre lang="diff"><code>blackwhite</code></pre>\n`;
+    const message = '😄begin' + 'a'.repeat(1_000_001) + 'this is at the end and should be in the output';
+    // const expected = `<h1>Pulumi ${projectName}/${defaultOptions.stackName} results</h1>\n<pre lang="diff"><code>blackwhite</code></pre>\n`;
 
     const options: Config = {
       ...defaultOptions,
@@ -89,7 +89,7 @@ describe('summary.ts', () => {
     expect(summary).toContain('this is at the end and should be in the output');
     expect(summary).toContain('The output was too long and trimmed from the front.');
     expect(summary).not.toContain('The output was too long and trimmed.');
-    expect(summary).toBe(expected);
+    // expect(summary).toBe(expected);
   })
 
   // const MAX_SUMMARY_SIZE_BYTES = 1_000_000;

--- a/src/libs/__tests__/summary.test.ts
+++ b/src/libs/__tests__/summary.test.ts
@@ -1,0 +1,96 @@
+import * as fs from 'fs'
+import path from 'path'
+import * as core from '@actions/core';
+import { SUMMARY_ENV_VAR } from '@actions/core/lib/summary'
+import { Config } from '../../config';
+import { handleSummaryMessage } from '../summary';
+
+const testDirectoryPath = path.join(__dirname, 'test')
+const testFilePath = path.join(testDirectoryPath, 'test-summary.md')
+
+async function getSummary(): Promise<string> {
+  const file = await fs.promises.readFile(testFilePath, {encoding: 'utf8'});
+  return file.replace(/\r\n/g, "\n");
+}
+
+const projectName = 'myFirstProject';
+const defaultOptions = {
+  command: 'preview',
+  stackName: 'staging',
+  options: {},
+} as Config;
+
+describe('summary.ts', () => {
+  beforeEach(async () => {
+    process.env[SUMMARY_ENV_VAR] = testFilePath;
+    await fs.promises.mkdir(testDirectoryPath, {recursive: true});
+    await fs.promises.writeFile(testFilePath, '', {encoding: 'utf8'});
+    core.summary.emptyBuffer();
+  })
+
+  afterAll(async () => {
+    await fs.promises.unlink(testFilePath);
+  })
+
+  it('throws if summary env var is undefined', async () => {
+    process.env[SUMMARY_ENV_VAR] = undefined;
+    const write = core.summary.addRaw('123').write();
+    await expect(write).rejects.toThrow();
+  })
+
+  it('throws if summary file does not exist', async () => {
+    await fs.promises.unlink(testFilePath);
+    const write = core.summary.addRaw('123').write();
+    await expect(write).rejects.toThrow();
+  })
+
+  it('should add only heading with empty code block to summary', async () => {
+    const message = '';
+    const expected = `<h1>Pulumi ${projectName}/${defaultOptions.stackName} results</h1>\n<pre lang="diff"><code></pre>\n`;
+
+    await handleSummaryMessage(defaultOptions, projectName, message);
+    const summary = await getSummary()
+    await expect(summary).toBe(expected);
+  })
+
+  it('should convert ansi control character to plain text and add to summary', async () => {
+    const message = '\x1b[30mblack\x1b[37mwhite';
+    const expected = `<h1>Pulumi ${projectName}/${defaultOptions.stackName} results</h1>\n<pre lang="diff"><code>blackwhite</code></pre>\n`;
+
+    await handleSummaryMessage(defaultOptions, projectName, message);
+    const summary = await getSummary()
+    await expect(summary).toBe(expected);
+  })
+
+  it('should trim the output when the output is larger than 1 MiB', async () => {
+    const message = 'a'.repeat(1_000_001);
+
+    await handleSummaryMessage(defaultOptions, projectName, message);
+    const summary = await getSummary()
+    expect(Buffer.byteLength(summary, 'utf8')).toBeLessThan(1_048_576);
+    expect(summary).toContain('The output was too long and trimmed.');
+    expect(summary).not.toContain('The output was too long and trimmed from the front.');
+  })
+
+  it('should trim the output from front when the output is larger than 1 MiB and config is set', async () => {
+    const message = '😄begin' + 'a'.repeat(65_536) + 'this is at the end and should be in the output';
+    const expected = `<h1>Pulumi ${projectName}/${defaultOptions.stackName} results</h1>\n<pre lang="diff"><code>blackwhite</code></pre>\n`;
+
+    const options: Config = {
+      ...defaultOptions,
+      alwaysIncludeSummary: true,
+    };
+
+    await handleSummaryMessage(options, projectName, message);
+    const summary = await getSummary()
+    // expect(summary.length).toBeLessThan(1);
+    // expect([...summary].length).toBeLessThan(1);
+    // expect(Buffer.byteLength(summary, 'utf8')).toBeLessThan(1);
+    expect(summary).toContain('this is at the end and should be in the output');
+    expect(summary).toContain('The output was too long and trimmed from the front.');
+    expect(summary).not.toContain('The output was too long and trimmed.');
+    expect(summary).toBe(expected);
+  })
+
+  // const MAX_SUMMARY_SIZE_BYTES = 1_000_000;
+})

--- a/src/libs/__tests__/summary.test.ts
+++ b/src/libs/__tests__/summary.test.ts
@@ -55,7 +55,7 @@ describe('summary.ts', () => {
 
   it('should convert ansi control character to plain text and add to summary', async () => {
     const message = '\x1b[30mblack\x1b[37mwhite';
-    const expected = `<h1>Pulumi ${projectName}/${defaultOptions.stackName} results</h1>\n<pre lang="diff"><code>\nblackwhite\n</code></pre>`;
+    const expected = `<h1>Pulumi ${projectName}/${defaultOptions.stackName} results</h1>\n<pre lang="diff"><code>blackwhite</code></pre>`;
 
     await handleSummaryMessage(defaultOptions, projectName, message);
     const summary = await getSummary()

--- a/src/libs/__tests__/summary.test.ts
+++ b/src/libs/__tests__/summary.test.ts
@@ -46,7 +46,7 @@ describe('summary.ts', () => {
 
   it('should add only heading with empty code block to summary', async () => {
     const message = '';
-    const expected = `<h1>Pulumi ${projectName}/${defaultOptions.stackName} results</h1>\n<pre lang="diff"><code></pre>\n`;
+    const expected = `<h1>Pulumi ${projectName}/${defaultOptions.stackName} results</h1>\n<pre lang="diff"><code>\n\n</code></pre>`;
 
     await handleSummaryMessage(defaultOptions, projectName, message);
     const summary = await getSummary()
@@ -55,7 +55,7 @@ describe('summary.ts', () => {
 
   it('should convert ansi control character to plain text and add to summary', async () => {
     const message = '\x1b[30mblack\x1b[37mwhite';
-    const expected = `<h1>Pulumi ${projectName}/${defaultOptions.stackName} results</h1>\n<pre lang="diff"><code>blackwhite</code></pre>\n`;
+    const expected = `<h1>Pulumi ${projectName}/${defaultOptions.stackName} results</h1>\n<pre lang="diff"><code>\nblackwhite\n</code></pre>`;
 
     await handleSummaryMessage(defaultOptions, projectName, message);
     const summary = await getSummary()

--- a/src/libs/pr.ts
+++ b/src/libs/pr.ts
@@ -1,11 +1,10 @@
 import * as core from '@actions/core';
 import { context, getOctokit } from '@actions/github';
-import AnsiToHtml from 'ansi-to-html';
 import dedent from 'dedent';
 import invariant from 'ts-invariant';
 import { Config } from '../config';
 
-function ansiToHtml(
+function trimOutput(
   message: string,
   maxLength: number,
   alwaysIncludeSummary: boolean,
@@ -18,30 +17,24 @@ function ansiToHtml(
    *
    *  return message as html and information if message was trimmed because of length
    */
-  const convert = new AnsiToHtml();
   let trimmed = false;
 
-  let htmlBody: string = convert.toHtml(message);
-
-  // Check if htmlBody exceeds max characters
-  if (htmlBody.length > maxLength) {
+  // Check if message exceeds max characters
+  if (message.length > maxLength) {
 
     // trim input message by number of exceeded characters from front or back as configured
-    const dif: number = htmlBody.length - maxLength;
+    const dif: number = message.length - maxLength;
 
     if (alwaysIncludeSummary) {
-      message = message.substring(dif, htmlBody.length);
+      message = message.substring(dif, message.length);
     } else {
       message = message.substring(0, message.length - dif);
     }
 
     trimmed = true;
-
-    // convert trimmed message to html
-    htmlBody = convert.toHtml(message);
   }
 
-  return [htmlBody, trimmed];
+  return [message, trimmed];
 }
 
 export async function handlePullRequestMessage(
@@ -64,7 +57,7 @@ export async function handlePullRequestMessage(
 
   const summary = '<summary>Pulumi report</summary>';
 
-  const [htmlBody, trimmed]: [string, boolean] = ansiToHtml(output, MAX_CHARACTER_COMMENT, alwaysIncludeSummary);
+  const [htmlBody, trimmed]: [string, boolean] = trimOutput(output, MAX_CHARACTER_COMMENT, alwaysIncludeSummary);
 
   const body = dedent`
     ${heading}

--- a/src/libs/pr.ts
+++ b/src/libs/pr.ts
@@ -1,7 +1,6 @@
 import * as core from '@actions/core';
 import { context, getOctokit } from '@actions/github';
 import dedent from 'dedent';
-import stripAnsi from 'strip-ansi';
 import invariant from 'ts-invariant';
 import { Config } from '../config';
 
@@ -51,8 +50,9 @@ export async function handlePullRequestMessage(
     alwaysIncludeSummary,
   } = config;
 
-  // strip ANSI symbols from output because it is not supported in PR comment
-  output = stripAnsi(output);
+  // strip ANSI symbols from message because it is not supported in GH step Summary
+  const regex = RegExp(`\x1B(?:[@-Z\\-_]|[[0-?]*[ -/]*[@-~])`, 'g');
+  output = output.replace(regex, '');
 
   // GitHub limits comment characters to 65535, use lower max to keep buffer for variable values
   const MAX_CHARACTER_COMMENT = 64_000;

--- a/src/libs/pr.ts
+++ b/src/libs/pr.ts
@@ -15,14 +15,14 @@ function trimOutput(
    *  maxLength: Maximum number of characters of final message
    *  alwaysIncludeSummary: if true, trim message from front (if trimming is needed), otherwise from end
    *
-   *  return message as html and information if message was trimmed because of length
+   *  return message and information if message was trimmed
    */
   let trimmed = false;
 
   // Check if message exceeds max characters
   if (message.length > maxLength) {
 
-    // trim input message by number of exceeded characters from front or back as configured
+    // Trim input message by number of exceeded characters from front or back as configured
     const dif: number = message.length - maxLength;
 
     if (alwaysIncludeSummary) {
@@ -50,11 +50,11 @@ export async function handlePullRequestMessage(
     alwaysIncludeSummary,
   } = config;
 
-  // strip ANSI symbols from message because it is not supported in GH step Summary
+  // Remove ANSI symbols from output because they are not supported in GitHub PR message
   const regex = RegExp(`\x1B(?:[@-Z\\-_]|[[0-?]*[ -/]*[@-~])`, 'g');
   output = output.replace(regex, '');
 
-  // GitHub limits comment characters to 65535, use lower max to keep buffer for variable values
+  // GitHub limits PR comment characters to 65_535, use lower max to keep buffer for variable values
   const MAX_CHARACTER_COMMENT = 64_000;
 
   const heading = `#### :tropical_drink: \`${command}\` on ${projectName}/${stackName}`;

--- a/src/libs/summary.ts
+++ b/src/libs/summary.ts
@@ -65,11 +65,13 @@ export async function handleSummaryMessage(
   }
 
   const body = dedent`
+    <pre lang="diff"><code>
     ${message}
-  `
+    </code></pre>
+  `;
 
   await core.summary
-  .addHeading(heading)
-  .addCodeBlock(body, "diff")
-  .write();
+    .addHeading(heading)
+    .addRaw(body)
+    .write();
 }

--- a/src/libs/summary.ts
+++ b/src/libs/summary.ts
@@ -48,8 +48,11 @@ export async function handleSummaryMessage(
   } = config;
 
   // strip ANSI symbols from message because it is not supported in GH step Summary
-  const regex = RegExp(`\x1B(?:[@-Z\\-_]|[[0-?]*[ -/]*[@-~])`, 'g');
-  output = output.replace(regex, '');
+  const regex_ansi = RegExp(`\x1B(?:[@-Z\\-_]|[[0-?]*[ -/]*[@-~])`, 'g');
+  output = output.replace(regex_ansi, '');
+
+  const regex_space = RegExp(`^[ ]`, 'gm');
+  output = output.replace(regex_space, '&nbsp;');
 
   // GitHub limits step Summary to 1 MiB (1_048_576 bytes), use lower max to keep buffer for variable values
   const MAX_SUMMARY_SIZE_BYTES = 1_000_000;
@@ -64,11 +67,7 @@ export async function handleSummaryMessage(
     heading += ' :warning: **Warn**: The output was too long and trimmed.';
   }
 
-  const body = dedent`
-    <pre lang="diff"><code>
-    ${message}
-    </code></pre>
-  `;
+  const body = dedent`<pre lang="diff"><code>${message}</code></pre>`;
 
   await core.summary
     .addHeading(heading)

--- a/src/libs/summary.ts
+++ b/src/libs/summary.ts
@@ -1,4 +1,5 @@
 import * as core from '@actions/core';
+import dedent from 'dedent';
 import { Config } from '../config';
 
 function trimOutput(
@@ -65,6 +66,6 @@ export async function handleSummaryMessage(
 
   await core.summary
   .addHeading(heading)
-  .addCodeBlock(message, "diff")
+  .addCodeBlock(dedent`${message}`, "diff")
   .write();
 }

--- a/src/libs/summary.ts
+++ b/src/libs/summary.ts
@@ -1,5 +1,4 @@
 import * as core from '@actions/core';
-import stripAnsi from 'strip-ansi';
 import { Config } from '../config';
 
 function trimOutput(
@@ -26,7 +25,7 @@ function trimOutput(
     const dif: number = messageSize - maxSize;
 
     if (alwaysIncludeSummary) {
-      message = Buffer.from(message).subarray(dif, maxSize).toString()
+      message = Buffer.from(message).subarray(dif, messageSize).toString()
     } else {
       message = Buffer.from(message).subarray(0, messageSize - dif).toString()
     }
@@ -48,7 +47,8 @@ export async function handleSummaryMessage(
   } = config;
 
   // strip ANSI symbols from message because it is not supported in GH step Summary
-  output = stripAnsi(output);
+  const regex = RegExp(`\x1B(?:[@-Z\\-_]|[[0-?]*[ -/]*[@-~])`, 'g');
+  output = output.replace(regex, '');
 
   // GitHub limits step Summary to 1 MiB (1_048_576 bytes), use lower max to keep buffer for variable values
   const MAX_SUMMARY_SIZE_BYTES = 1_000_000;

--- a/src/libs/summary.ts
+++ b/src/libs/summary.ts
@@ -1,5 +1,4 @@
 import * as core from '@actions/core';
-import dedent from 'dedent';
 import { Config } from '../config';
 
 function trimOutput(
@@ -8,12 +7,12 @@ function trimOutput(
   alwaysIncludeSummary: boolean,
 ): [string, boolean] {
   /**
-   *  Trim message to maxSize in bytes by for example removing color escape characters
-   *  message: ansi string to trim
+   *  Trim message to maxSize in bytes
+   *  message: string to trim
    *  maxSize: Maximum number of bytes of final message
    *  alwaysIncludeSummary: if true, trim message from front (if trimming is needed), otherwise from end
    *
-   *  return message and information if message was trimmed because of size
+   *  return message and information if message was trimmed
    */
   let trimmed = false;
 
@@ -22,7 +21,7 @@ function trimOutput(
   // Check if message exceeds max size
   if (messageSize > maxSize) {
 
-    // trim input message by number of exceeded bytes from front or back as configured
+    // Trim input message by number of exceeded bytes from front or back as configured
     const dif: number = messageSize - maxSize;
 
     if (alwaysIncludeSummary) {
@@ -47,10 +46,11 @@ export async function handleSummaryMessage(
     alwaysIncludeSummary,
   } = config;
 
-  // strip ANSI symbols from message because it is not supported in GH step Summary
+  // Remove ANSI symbols from output because they are not supported in GitHub step Summary
   const regex_ansi = RegExp(`\x1B(?:[@-Z\\-_]|[[0-?]*[ -/]*[@-~])`, 'g');
   output = output.replace(regex_ansi, '');
 
+  // Replace the first leading space in each line with a non-breaking space character to preserve the formatting
   const regex_space = RegExp(`^[ ]`, 'gm');
   output = output.replace(regex_space, '&nbsp;');
 
@@ -67,10 +67,8 @@ export async function handleSummaryMessage(
     heading += ' :warning: **Warn**: The output was too long and trimmed.';
   }
 
-  const body = dedent`<pre lang="diff"><code>${message}</code></pre>`;
-
   await core.summary
     .addHeading(heading)
-    .addRaw(body)
+    .addCodeBlock(message, "diff")
     .write();
 }

--- a/src/libs/summary.ts
+++ b/src/libs/summary.ts
@@ -1,0 +1,65 @@
+import * as core from '@actions/core';
+import { Config } from '../config';
+
+function trimOutput(
+  message: string,
+  maxSize: number,
+  alwaysIncludeSummary: boolean,
+): [string, boolean] {
+  /**
+   *  Trim message to maxSize in bytes
+   *  message: string to convert
+   *  maxSize: Maximum number of bytes of final message
+   *  alwaysIncludeSummary: if true, trim message from front (if trimming is needed), otherwise from end
+   *
+   *  return message and information if message was trimmed because of size
+   */
+  let trimmed = false;
+
+  const messageSize = Buffer.byteLength(message, 'utf8');
+
+  // Check if message exceeds max size
+  if (messageSize > maxSize) {
+
+    // trim input message by number of exceeded bytes from front or back as configured
+    const dif: number = messageSize - maxSize;
+
+    if (alwaysIncludeSummary) {
+      message = Buffer.from(message).subarray(dif, maxSize).toString()
+    } else {
+      message = Buffer.from(message).subarray(0, messageSize - dif).toString()
+    }
+
+    trimmed = true;
+  }
+
+  return [message, trimmed];
+}
+
+export async function handleSummaryMessage(
+  config: Config,
+  projectName: string,
+  output: string,
+): Promise<void> {
+  const {
+    alwaysIncludeSummary,
+  } = config;
+
+  // GitHub limits step Summary to 1 MiB (1_048_576 bytes), use lower max to keep buffer for variable values
+  const MAX_SUMMARY_SIZE_BYTES = 1_000_000;
+
+  const [message, trimmed]: [string, boolean] = trimOutput(output, MAX_SUMMARY_SIZE_BYTES, alwaysIncludeSummary);
+
+  let heading;
+
+  if (trimmed) {
+    heading = 'Pulumi ${config.stackName} results (trimmed)';
+  } else {
+    heading = 'Pulumi ${config.stackName} results';
+  }
+
+  await core.summary
+  .addHeading(heading)
+  .addCodeBlock(message, "diff")
+  .write();
+}

--- a/src/libs/summary.ts
+++ b/src/libs/summary.ts
@@ -42,6 +42,7 @@ export async function handleSummaryMessage(
   output: string,
 ): Promise<void> {
   const {
+    stackName,
     alwaysIncludeSummary,
   } = config;
 
@@ -53,9 +54,9 @@ export async function handleSummaryMessage(
   let heading;
 
   if (trimmed) {
-    heading = 'Pulumi ${config.stackName} results (trimmed)';
+    heading = `Pulumi ${projectName}/${stackName} results (trimmed)`;
   } else {
-    heading = 'Pulumi ${config.stackName} results';
+    heading = `Pulumi ${config.stackName} results`;
   }
 
   await core.summary

--- a/src/libs/summary.ts
+++ b/src/libs/summary.ts
@@ -64,8 +64,12 @@ export async function handleSummaryMessage(
     heading += ' :warning: **Warn**: The output was too long and trimmed.';
   }
 
+  const body = dedent`
+    ${message}
+  `
+
   await core.summary
   .addHeading(heading)
-  .addCodeBlock(dedent`${message}`, "diff")
+  .addCodeBlock(body, "diff")
   .write();
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,6 @@ import {
   LocalWorkspace,
   LocalWorkspaceOptions,
 } from '@pulumi/pulumi/automation';
-import stripAnsi from 'strip-ansi';
 import invariant from 'ts-invariant';
 import {
   Commands,
@@ -116,19 +115,16 @@ const runAction = async (config: Config): Promise<void> => {
     }
   }
 
-  // strip ansi symbols from output because it is not supported in PR comment and Summary
-  const stripped_output = stripAnsi(output);
-
   const isPullRequest = context.payload.pull_request !== undefined;
   if (config.commentOnPrNumber ||
       (config.commentOnPr && isPullRequest)) {
     core.debug(`Commenting on pull request`);
     invariant(config.githubToken, 'github-token is missing.');
-    handlePullRequestMessage(config, projectName, stripped_output);
+    handlePullRequestMessage(config, projectName, output);
   }
 
   if (config.commentOnSummary) {
-    handleSummaryMessage(config, projectName, stripped_output)
+    handleSummaryMessage(config, projectName, output)
   }
 
   if (config.remove && config.command === 'destroy') {

--- a/src/main.ts
+++ b/src/main.ts
@@ -117,10 +117,7 @@ const runAction = async (config: Config): Promise<void> => {
   }
 
   // strip ansi symbols from output because it is not supported in PR comment and Summary
-  let stripped_output = output;
-  if (config.options.color == 'always') {
-    stripped_output = stripAnsi(output)
-  }
+  const stripped_output = stripAnsi(output);
 
   const isPullRequest = context.payload.pull_request !== undefined;
   if (config.commentOnPrNumber ||

--- a/src/main.ts
+++ b/src/main.ts
@@ -155,6 +155,7 @@ const runAction = async (config: Config): Promise<void> => {
       invariant(config.githubToken, 'github-token is missing.');
       handlePullRequestMessage(config, projectName, stdout);
     }
+  }
 
   if (config.commentOnSummary) {
     handleSummaryMessage(config, projectName, stdout)


### PR DESCRIPTION
This PR introduces striping of ANSI symbols for GitHub step Summary and improves the current one for PR comments.

To resolve #1248

This is similar to #1231, but uses a slightly different approach. Instead of converting ANSI symbols to html tags (using the `ansi-to-html` package), which results in `\x1b[30mblack` becoming `<span style="color:#000">black</span>`, we simply remove them using a regular expression, which results in `\x1b[30mblack` becoming just `black`. 

The reason is that neither the Summary nor the PR comment is able to actually render the `<span style="color:#000">` block with color. However, all these html tags consume limits for PR comment length and Summary size.