### PR TITLE
Log stderr from commands.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - fix: Make `pulumi login` respect configuration in `Pulumi.yaml`
   ([#1299](https://github.com/pulumi/actions/pull/1299))
+- fix: Log stderr from commands
+  ([#1316](https://github.com/pulumi/actions/issues/1316))
 
 ---
 


### PR DESCRIPTION
Users need to be able to know any diagnostics emitted by actions, so
this change adds some logging around stderr.

Fixes #1316
