### PR TITLE
Fix the `output` command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,26 @@ jobs:
           work-dir: .github/test-stacks/golang
           config-map: "{name: {value: test, secret: false}}"
       - run: echo 'The random string is `${{ steps.pulumi.outputs.name }}`'
+      - uses: ./
+        if: always()
+        id: pulumioutput
+        env:
+          PULUMI_CONFIG_PASSPHRASE: not-a-secret
+        with:
+          command: output
+          cloud-url: file://~
+          stack-name: organization/golang/dev
+      - run: echo 'The random string is `${{ steps.pulumioutput.outputs.name }}`'
+      - name: Compare Outputs
+        id: compare
+        run: |
+          if [[ "$OUTPUT1" != "$OUTPUT2" ]]; then
+            echo "Outputs are not equal!"
+            exit 1
+          fi
+        env:
+          OUTPUT1: ${{ steps.pulumi.outputs.name }}
+          OUTPUT2: ${{ steps.pulumioutput.outputs.name }}
   test-update-plan: # make sure the action works on a clean machine without building
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -162,6 +162,19 @@ jobs:
         with:
           dotnet-version: 6.x
 
+      - name: Ensure Stack Exists
+        if: matrix.command == 'output'
+        uses: ./
+        env:
+          PULUMI_CONFIG_PASSPHRASE: not-a-secret
+        with:
+          command: preview
+          cloud-url: file://~
+          upsert: true
+          stack-name: dev
+          work-dir: .github/test-stacks/dotnet
+          config-map: '{name: {value: my-pet, secret: false}}'
+
       - uses: ./
         env:
           PULUMI_CONFIG_PASSPHRASE: not-a-secret
@@ -241,6 +254,19 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 1.22.x
+
+      - name: Ensure Stack Exists
+        if: matrix.command == 'output'
+        uses: ./
+        env:
+          PULUMI_CONFIG_PASSPHRASE: not-a-secret
+        with:
+          command: preview
+          cloud-url: file://~
+          upsert: true
+          stack-name: dev
+          work-dir: .github/test-stacks/golang
+          config-map: '{name: {value: my-user-name, secret: false}}'
 
       - uses: ./
         env:
@@ -325,6 +351,19 @@ jobs:
 
       - run: npm install
         working-directory: .github/test-stacks/nodejs
+
+      - name: Ensure Stack Exists
+        if: matrix.command == 'output'
+        uses: ./
+        env:
+          PULUMI_CONFIG_PASSPHRASE: not-a-secret
+        with:
+          command: preview
+          cloud-url: file://~
+          upsert: true
+          stack-name: dev
+          work-dir: .github/test-stacks/nodejs
+          config-map: '{name: {value: hostname, secret: false}}'
 
       - uses: ./
         env:
@@ -433,6 +472,19 @@ jobs:
 
       - run: pip install -r requirements.txt
         working-directory: .github/test-stacks/python
+
+      - name: Ensure Stack Exists
+        if: matrix.command == 'output'
+        uses: ./
+        env:
+          PULUMI_CONFIG_PASSPHRASE: not-a-secret
+        with:
+          command: preview
+          cloud-url: file://~
+          upsert: true
+          stack-name: dev
+          work-dir: .github/test-stacks/python
+          config-map: '{name: {value: hostname, secret: false}}'
 
       - uses: ./
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - fix: Log stderr from commands
   ([#1316](https://github.com/pulumi/actions/issues/1316))
 
+- fix: Make the `output` command work without having to be in a working
+  directory that contains a Pulumi.yaml file.
+  ([#1327](https://github.com/pulumi/actions/pull/1327))
+
 ---
 
 ## 6.0.0 (2024-09-27)


### PR DESCRIPTION
This commit fixes the `output` command to work without having to have a workDir specified to a location with a Pulumi.yaml file. It does this by avoiding calls to `LocalWorkspace.createOrSelectStack`/`selectStack` when the command is `output`. This allows the `output` command to work with any stack, even when there is not a local project available.

Additionally, when the command is `output`, don't attempt to comment on the PR; only actual pulumi operations (like the `up` command) should do that.

Fixes #868