### PR TITLE
Add a clickable View Live link before pre-block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## HEAD (Unreleased)
 
-**(none)**
+- feat: Add clickable View Live link to PR comments
+  ([#1355](https://github.com/pulumi/actions/pull/1355))
 
 ---
 

--- a/src/libs/__tests__/pr.test.ts
+++ b/src/libs/__tests__/pr.test.ts
@@ -213,7 +213,7 @@ describe('pr.ts', () => {
 
     await handlePullRequestMessage(options, projectName, 'View Live: https://example.com/update/1\ntest');
     expect(createComment).toHaveBeenCalledWith({
-      body: '#### :tropical_drink: `preview` on myFirstProject/staging\n\n<details>\n<summary>Pulumi report</summary>\n[View Live](https://example.com/update/1)\n\n\n<pre>\nView Live: https://example.com/update/1\ntest\n</pre>\n\n</details>',
+      body: '#### :tropical_drink: `preview` on myFirstProject/staging\n\n<details>\n<summary>Pulumi report</summary>\n\n[View in Pulumi Cloud](https://example.com/update/1)\n\n\n<pre>\nView Live: https://example.com/update/1\ntest\n</pre>\n\n</details>',
       issue_number: 87,
     });
   });

--- a/src/libs/__tests__/pr.test.ts
+++ b/src/libs/__tests__/pr.test.ts
@@ -195,4 +195,26 @@ describe('pr.ts', () => {
       body: '#### :tropical_drink: `preview` on myFirstProject/staging\n\n<details>\n<summary>Pulumi report</summary>\n\n\n<pre>\ntest\n</pre>\n\n</details>',
     });
   });
+
+  it('should add a clickable link to the update run', async () => {
+    // @ts-ignore
+    gh.context = {
+      payload: {
+        pull_request: {
+          number: 123,
+        },
+      },
+    };
+
+    const options: Config = {
+      ...defaultOptions,
+      commentOnPrNumber: 87,
+    };
+
+    await handlePullRequestMessage(options, projectName, 'View Live: https://example.com/update/1\ntest');
+    expect(createComment).toHaveBeenCalledWith({
+      body: '#### :tropical_drink: `preview` on myFirstProject/staging\n\n<details>\n<summary>Pulumi report</summary>\n[View Live](https://example.com/update/1)\n\n\n<pre>\nView Live: https://example.com/update/1\ntest\n</pre>\n\n</details>',
+      issue_number: 87,
+    });
+  });
 });

--- a/src/libs/pr.ts
+++ b/src/libs/pr.ts
@@ -88,7 +88,7 @@ export async function handlePullRequestMessage(
 
     <details>
     ${summary}
-    ${viewLiveLink ? `[View Live](${viewLiveLink})\n` : ''}
+    ${viewLiveLink ? `[View in Pulumi Cloud](${viewLiveLink})\n` : ''}
     ${trimmed && alwaysIncludeSummary
       ? ':warning: **Warn**: The output was too long and trimmed from the front.'
       : ''

--- a/src/libs/pr.ts
+++ b/src/libs/pr.ts
@@ -88,7 +88,7 @@ export async function handlePullRequestMessage(
 
     <details>
     ${summary}
-    ${viewLiveLink ? `[View in Pulumi Cloud](${viewLiveLink})\n` : ''}
+    ${viewLiveLink ? `\n[View in Pulumi Cloud](${viewLiveLink})\n` : ''}
     ${trimmed && alwaysIncludeSummary
       ? ':warning: **Warn**: The output was too long and trimmed from the front.'
       : ''

--- a/src/libs/pr.ts
+++ b/src/libs/pr.ts
@@ -44,6 +44,21 @@ function ansiToHtml(
   return [htmlBody, trimmed];
 }
 
+function extractViewLiveLink(output: string) {
+  /**
+   *  Extracts the Pulumi preview link from the output
+   *  output: pulumi preview output
+   *
+   *  return link to the Pulumi preview
+   */
+  const lines = output.split('\n');
+  const linkLine = lines.find((line) => line.includes('View Live:'));
+  if (!linkLine) {
+    return '';
+  }
+  return linkLine.split('View Live: ')[1];
+}
+
 export async function handlePullRequestMessage(
   config: Config,
   projectName: string,
@@ -66,12 +81,14 @@ export async function handlePullRequestMessage(
 
   const [htmlBody, trimmed]: [string, boolean] = ansiToHtml(output, MAX_CHARACTER_COMMENT, alwaysIncludeSummary);
 
+  const viewLiveLink = extractViewLiveLink(output);
+
   const body = dedent`
     ${heading}
 
     <details>
     ${summary}
-
+    ${viewLiveLink ? `[View Live](${viewLiveLink})\n` : ''}
     ${trimmed && alwaysIncludeSummary
       ? ':warning: **Warn**: The output was too long and trimmed from the front.'
       : ''


### PR DESCRIPTION
👋🏼 

I brought this up in my company's shared Slack with y'all. Seemed pretty low effort so I decided to forego the issue creation.

The idea is to offer a clickable link to the update run. Currently, since it is within the `<pre>` tags, the link is not clickable and must be highlighted in a window that is likely horizontally scrolling. The other alternative is to find the clickable link within the GitHub Action logs.

We've seen a few times where both the author and the reviewer have failed to double-check the preview run to ensure we're not causing any surprises. My hope is that by making it easier to double-check the preview output in Pulumi, that the likelihood of forgetting to check the output will decrease.

I could see an argument for putting the `View Live` link outside of the `<details>` section entirely so it is only a click away, but I wanted to propose these changes as they are to get a discussion started.

Thanks!