### PR TITLE
update "user agent" string from `pulumi/actions@v5` to `pulumi/actions@v6`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## HEAD (Unreleased)
 
 - feat: verbosity and debug inputs to enable debug options
+  ([#1046](https://github.com/pulumi/actions/pull/1046))
+
+- fix: update "user agent" string to pulumi/actions@v6
+  ([#1357](https://github.com/pulumi/actions/pull/1367))
 
 ---
 

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -74,7 +74,7 @@ describe('config.ts', () => {
           "suppressProgress": false,
           "target": Array [],
           "targetDependents": false,
-          "userAgent": "pulumi/actions@v5",
+          "userAgent": "pulumi/actions@v6",
         },
         "pulumiVersion": "^3",
         "remove": false,

--- a/src/config.ts
+++ b/src/config.ts
@@ -106,7 +106,7 @@ export function makeConfig() {
       policyPackConfigs: parseSemicolorToArray(
         getMultilineInput('policyPackConfigs'),
       ),
-      userAgent: 'pulumi/actions@v5',
+      userAgent: 'pulumi/actions@v6',
       color: getUnionInput('color', {
         alternatives: ['always', 'never', 'raw', 'auto'] as const,
       }),


### PR DESCRIPTION
The action code provides a user agent string to the automation api, for informational purposes.  Looks like the string is out of date; it still says "v5".  For example, some output from an unrelated issue:

```
stderr: Command failed with exit code 255: pulumi up --yes --skip-preview --diff --exec-agent pulumi/actions@v5 --color auto --exec-kind auto.local --stack dev-eus-00-wil-in1 --non-interactive
[resource plugin random-4.18.2] installing
[resource plugin random-4.18.1] installing
[resource plugin random-4.18.0] installing
[resource plugin azuread-6.4.0] installing
[resource plugin azure-native-3.2.0] installing
error: Status=400 Code="CertificateInUse" Message="Certificate 'cert-d5add54c6ad5054e50af24f769f45cf5' is used by existing custom domains."
```