### PR TITLE
use org level actions secrets

### DIFF
--- a/.github/workflows/update_dist.yml
+++ b/.github/workflows/update_dist.yml
@@ -8,7 +8,7 @@ env:
   ESC_ACTION_OIDC_AUTH: true
   ESC_ACTION_OIDC_ORGANIZATION: pulumi
   ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
-  ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-actions
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
   ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=PULUMI_BOT_TOKEN
 
 jobs:


### PR DESCRIPTION
The github-secrets/pulumi-actions environment doesn't exist in ESC, making the update_dist CI job fail.  We don't need a separate ESC environment for this Job, we just need the org level secrets, that exist in imports/github-secrets.  So instead of creating another separte environment, let's just reuse that.

Fixes https://github.com/pulumi/actions/issues/1372