### PR TITLE
Add preview-only flag support for destroy command

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ The action can be configured with the following arguments:
 - `exclude-protected` - (optional) Skip destroying protected resources. Only
   valid when `command` is `destroy`.
 
+- `preview-only` - (optional) Only show a preview of the operation, but do not
+  perform it. Only valid when `command` is `destroy`.
+
 - `suppress-outputs` - (optional) Suppress display of stack outputs (in case
   they contain sensitive values).
 

--- a/action.yml
+++ b/action.yml
@@ -106,6 +106,10 @@ inputs:
     description: 'Skip destroying protected resources. Only valid when command is destroy.'
     required: false
     default: 'false'
+  preview-only:
+    description: 'Only show a preview of the operation, but do not perform it. Only valid when command is destroy.'
+    required: false
+    default: 'false'
   plan:
     description: 'Where to either save an Update Plan or read an Update Plan from'
     required: false

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -19,6 +19,7 @@ const defaultConfig: Record<string, string> = {
   'target-dependents': 'false',
   'exclude-dependents': 'false',
   'exclude-protected': 'false',
+  'preview-only': 'false',
   plan: '',
   'suppress-outputs': 'false',
   'suppress-progress': 'false',
@@ -70,6 +71,7 @@ describe('config.ts', () => {
           "parallel": undefined,
           "plan": "",
           "policyPackConfigs": Array [],
+          "previewOnly": false,
           "policyPacks": Array [],
           "refresh": false,
           "replace": Array [],
@@ -98,6 +100,16 @@ describe('config.ts', () => {
     expect(() => makeConfig()).toThrowErrorMatchingInlineSnapshot(
       `"Input was not correct for command. Valid alternatives are: up, update, refresh, destroy, preview, output"`,
     );
+  });
+
+  it('should handle preview-only option correctly', async () => {
+    setupMockedConfig({
+      ...defaultConfig,
+      'preview-only': 'true',
+    });
+
+    const config = makeConfig();
+    expect(config.options.previewOnly).toBe(true);
   });
 
   it('should return ^3 if pulumi-version is undefined', async () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -113,6 +113,7 @@ export function makeConfig() {
         alternatives: ['always', 'never', 'raw', 'auto'] as const,
       }),
       excludeProtected: getBooleanInput('exclude-protected'),
+      previewOnly: getBooleanInput('preview-only'),
       plan: getInput('plan'),
       suppressOutputs: getBooleanInput('suppress-outputs'),
       suppressProgress: getBooleanInput('suppress-progress'),


### PR DESCRIPTION
Closes #1275 

**Note that I vibe coded this and haven't yet reviewed or tested it. I'll mark the PR as ready for review and remove this message once it's ready!**

This adds a new `preview-only` input parameter that allows users to preview what would be destroyed without actually performing the destruction. This is equivalent to running `pulumi destroy --preview-only` from the CLI.

Changes:
- Added `preview-only` input parameter to action.yml
- Updated config.ts to handle the new parameter
- Added tests for the new functionality
- Updated README.md documentation