### PR TITLE
Bump Node runtime from 20 to 24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 24.x
           cache: yarn
       - run: yarn install
       - run: yarn build
@@ -38,7 +38,7 @@ jobs:
           PULUMI_CONFIG_PASSPHRASE: not-a-secret
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 24.x
           cache: yarn
       - run: yarn install
       - run: yarn build
@@ -95,7 +95,7 @@ jobs:
           PULUMI_CONFIG_PASSPHRASE: not-a-secret
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 24.x
           cache: yarn
       - run: yarn install
       - run: yarn build
@@ -140,7 +140,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 24.x
           cache: yarn
       - run: yarn install
       - run: yarn build

--- a/.github/workflows/update_dist.yml
+++ b/.github/workflows/update_dist.yml
@@ -23,7 +23,7 @@ jobs:
           token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 24.x
           cache: yarn
       - run: yarn install
       - run: yarn build

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 24.x
           cache: yarn
 
       - run: yarn install
@@ -346,7 +346,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 24.x
           cache: npm
 
       - run: npm install
@@ -563,7 +563,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 24.x
           cache: npm
 
       - run: npm install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## HEAD (Unreleased)
 
-**(none)**
+- chore: update Action runtime to node 24
+  ([#1404](https://github.com/pulumi/actions/pull/1404))
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -259,6 +259,12 @@ the correct GitHub Marketplace actions that support it.
 We're releasing new version of the actions as needed, releasing minor versions
 whenever new features are introduced, and patch releases for bug fixes only.
 
+## Migrating from v6
+
+v7 of the Pulumi Action updates the NodeJS runtime from Node 20 to Node 24.
+Users of GitHub Enterprise will have to upgrade to v3.18 or newer. All other
+users are unaffected.
+
 ## Migrating from v5
 
 v6 of the Pulumi Action updates the behavior of the `refresh` option.

--- a/action.yml
+++ b/action.yml
@@ -140,12 +140,5 @@ outputs:
   output:
     description: Output from running command
 runs:
-  # TODO upgrade to node16 by 1 Nov 2022.
-  #
-  # We will retain node12 requirement 6 months after its EOL (30 Apr
-  # 2022), unless something forces us to upgrade.
-  #
-  # Trying to upgrade in July 2022 broke our users that depend on
-  # GitHub Enterprise versions < 3.4
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1394,10 +1394,15 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@>=13.7.0", "@types/node@~20.4.9":
+"@types/node@*", "@types/node@>=13.7.0":
   version "20.4.9"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.4.9.tgz#c7164e0f8d3f12dfae336af0b1f7fdec8c6b204f"
   integrity sha512-8e2HYcg7ohnTUbHk8focoklEQYvemQmu9M/f43DZVx43kHn0tE3BY/6gSDxS7k0SprtS0NHvj+L80cGLnoOUcQ==
+
+"@types/node@~20.4.9":
+  version "20.4.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.4.10.tgz#73c9480791e3ddeb4887a660fc93a7f59353ad45"
+  integrity sha512-vwzFiiy8Rn6E0MtA13/Cxxgpan/N6UeNYR9oUu6kuJWxu6zCk98trcDp8CBhbtaeuq9SykCmXkFr2lWLoPcvLg==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"


### PR DESCRIPTION
## Summary

GitHub is deprecating the `node20` Actions runtime. This bumps the action to `node24`.

## Test plan

- [x] \`yarn test\` passes on Node 24 locally
- [x] \`yarn build\` succeeds on Node 24 locally
- [x] Smoke test: \`node dist/index.js\` loads bundle cleanly on Node 24
- [ ] CI green on this PR
- [ ] Maintainer-triggered run for secrets-gated jobs (fork PRs don't have access to org secrets)

Closes https://github.com/pulumi/actions/issues/1403