### PR TITLE
Add 6.5.0 release to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@
 - feat: Strip ansi control characters from GitHub step Summary and PR comment
   ([#1312](https://github.com/pulumi/actions/pull/1312))
 
+## 6.5.0 (2025-07-17)
+
+- revert: Remove `run-program` flag support
+  ([#1381](https://github.com/pulumi/actions/pull/1381))
+
 ## 6.4.0 (2025-07-16)
 
 - feat: Add `run-program` flag support for refresh, destroy, preview, and


### PR DESCRIPTION
I thought the `run-program` option was supported because it was added in `6.4.0`, but later discovered it was removed in `6.5.0`. This PR includes the removal in the changelog to make that more visible.