### PR TITLE
ci: skip fork PRs when picking a PR for test-pr-version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -147,10 +147,11 @@ jobs:
       # We use the last merged PR to guarantee we are not trying to access an artifact that has been deleted.
       # GitHub automatically deletes workflow artifacts after a retention period, so using a recent merged PR
       # ensures the PR build artifacts are still available for testing.
+      # Fork (community) PRs are excluded: their CI runs don't upload CLI artifacts.
       - name: Get last merged PR number
         id: get-pr
         run: |
-          PR_NUMBER=$(gh pr list --repo pulumi/pulumi --state merged --limit 1 --json number --jq '.[0].number')
+          PR_NUMBER=$(gh pr list --repo pulumi/pulumi --state merged --limit 20 --json number,isCrossRepository --jq '[.[] | select(.isCrossRepository | not)][0].number')
           echo "pr-number=$PR_NUMBER" >> $GITHUB_OUTPUT
           echo "Using PR #$PR_NUMBER"
         env:


### PR DESCRIPTION
## Summary

The `test-pr-version` job installs Pulumi from the most recently merged pulumi/pulumi PR to exercise the `pulumi-version: pr#N` install path. When that PR comes from a fork (community PR), its CI run does not upload CLI artifacts, so the job fails with:

```
Could not find artifact artifacts-cli-linux-amd64
```

This is currently breaking `test-pr-version` on every branch (including `main`, run [32853057394](https://github.com/pulumi/actions/actions/runs/32853057394)) because pulumi/pulumi#24447 — a fork PR whose CI run has zero artifacts — is the most recently created merged PR.

## Fix

Filter out cross-repository PRs when picking the PR, so we always select a same-repo PR whose CI run uploaded the CLI binaries. Verified the new query returns pulumi/pulumi#24443, whose CI run has `artifacts-cli-linux-amd64`.